### PR TITLE
Handle missing prayer times gracefully

### DIFF
--- a/app/src/main/java/com/example/abys/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/MainViewModel.kt
@@ -64,7 +64,10 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
             val han = runCatching { aladhan.timingsByCity(city = city, school = 1) }.getOrNull()
             if (std != null && han != null) {
                 val tz = ZoneId.of(std.data.meta.timezone)
-                val parts = TimeUtils.splitNight(std.data.timings.Maghrib, std.data.timings.Fajr, tz)
+                val parts = runCatching {
+                    TimeUtils.splitNight(std.data.timings.Maghrib, std.data.timings.Fajr, tz)
+                }.onFailure { println("splitNight error: ${'$'}{it.message}") }
+                    .getOrNull() ?: return@launch
                 _timings.value = TimingsUi(
                     fajr = std.data.timings.Fajr,
                     sunrise = std.data.timings.Sunrise,
@@ -98,7 +101,10 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
             val han = runCatching { aladhan.timingsByCoords(lat, lon, school = 1) }.getOrNull()
             if (std != null && han != null) {
                 val tz = ZoneId.of(std.data.meta.timezone)
-                val parts = TimeUtils.splitNight(std.data.timings.Maghrib, std.data.timings.Fajr, tz)
+                val parts = runCatching {
+                    TimeUtils.splitNight(std.data.timings.Maghrib, std.data.timings.Fajr, tz)
+                }.onFailure { println("splitNight error: ${'$'}{it.message}") }
+                    .getOrNull() ?: return@launch
                 _timings.value = TimingsUi(
                     fajr = std.data.timings.Fajr,
                     sunrise = std.data.timings.Sunrise,

--- a/app/src/main/java/com/example/abys/util/TimeUtils.kt
+++ b/app/src/main/java/com/example/abys/util/TimeUtils.kt
@@ -5,10 +5,18 @@ import java.time.*
 object TimeUtils {
     private val hm = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
 
+    class InvalidTimeException(message: String) : Exception(message)
+
     fun parseLocal(time: String, zone: ZoneId): ZonedDateTime {
-        val today = LocalDate.now(zone)
-        val lt = LocalTime.parse(time.take(5), hm)
-        return ZonedDateTime.of(today, lt, zone)
+        if (time.startsWith("--")) throw InvalidTimeException("Time not available")
+        return if (time.contains('T')) {
+            val odt = OffsetDateTime.parse(time)
+            odt.atZoneSameInstant(zone)
+        } else {
+            val today = LocalDate.now(zone)
+            val lt = LocalTime.parse(time.take(5), hm)
+            ZonedDateTime.of(today, lt, zone)
+        }
     }
 
     data class NightParts(


### PR DESCRIPTION
## Summary
- parse ISO timestamps and missing values in `TimeUtils`
- guard night-splitting logic in `MainViewModel` with error handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cee0151c832daccbd0a902d2ab84