### PR TITLE
Play intro video on splash screen

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screens/SplashThen.kt
+++ b/app/src/main/java/com/example/abys/ui/screens/SplashThen.kt
@@ -1,35 +1,49 @@
 package com.example.abys.ui.screens
 
+import android.net.Uri
+import android.widget.VideoView
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.viewinterop.AndroidView
 import com.example.abys.R
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun SplashThen(content: @Composable () -> Unit) {
     var show by remember { mutableStateOf(true) }
-    LaunchedEffect(Unit) { delay(1500); show = false }   // 1.5 сек приветствия
+    val scope = rememberCoroutineScope()
     AnimatedContent(
         targetState = show,
         transitionSpec = { fadeIn(tween(600)) togetherWith fadeOut(tween(600)) },
-        label = "splash"
+        label = "splash",
     ) { s ->
         if (s) {
-            Image(
-                painter = painterResource(R.drawable.greeting_abys),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = { ctx ->
+                    VideoView(ctx).apply {
+                        setVideoURI(
+                            Uri.parse("android.resource://${ctx.packageName}/${R.raw.greeting_intro}")
+                        )
+                        setOnPreparedListener { mp ->
+                            mp.isLooping = false
+                            start()
+                            scope.launch {
+                                delay(5_000)
+                                show = false
+                            }
+                        }
+                    }
+                }
             )
+            // Place greeting_intro.mp4 (5s) in app/src/main/res/raw/
         } else {
             content()
         }


### PR DESCRIPTION
## Summary
- Display 5-second `greeting_intro.mp4` splash video using `AndroidView` with `VideoView`.
- Auto-hide splash after video playback and transition to main content.
- Provide path hint for placing `greeting_intro.mp4` without bundling the file.

## Testing
- `bash gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cede4288832d9e2ab1cecce7e20f