### PR TITLE
Specify default body font family

### DIFF
--- a/app/src/main/java/com/example/abys/ui/theme/BMTheme.kt
+++ b/app/src/main/java/com/example/abys/ui/theme/BMTheme.kt
@@ -30,7 +30,7 @@ private val blackLetter = FontFamily(
 private val bmTypography = Typography(
     displayLarge = TextStyle(fontFamily = blackLetter, fontSize = 32.sp, lineHeight = 36.sp),
     titleMedium  = TextStyle(fontFamily = blackLetter, fontSize = 18.sp),
-    bodyLarge    = TextStyle(fontSize = 16.sp)
+    bodyLarge    = TextStyle(fontFamily = FontFamily.Default, fontSize = 16.sp)
 )
 
 // ----------  Тема  ----------


### PR DESCRIPTION
## Summary
- ensure the body text style explicitly uses the default font family while keeping the new blackletter styles for headings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec27134e78832d8b32c87bc9683fbd