### PR TITLE
Fix XML resource namespace errors

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rootHost"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/app/src/main/res/layout/item_prayer_card.xml
+++ b/app/src/main/res/layout/item_prayer_card.xml
@@ -1,4 +1,3 @@
-<!-- app/src/main/res/layout/item_prayer_card.xml -->
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"


### PR DESCRIPTION
## Summary
- remove the comment preceding the XML declaration in `item_prayer_card.xml` so the resource parser accepts the layout
- declare the `app` namespace in `activity_main.xml` to allow Material component attributes to compile

## Testing
- ./gradlew :app:mergeDebugResources --console=plain --no-daemon *(hangs in container before producing output)*

------
https://chatgpt.com/codex/tasks/task_e_68ec307a992c832d81216ce54d487dbe