### PR TITLE
Fix MainActivity seasonal particles import and city picker call

### DIFF
--- a/app/src/main/java/com/example/abys/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/MainActivity.kt
@@ -38,9 +38,10 @@ import androidx.compose.ui.platform.ComposeView
 import com.example.abys.ui.background.SlideshowBackground
 import com.example.abys.ui.components.GlassCard
 import com.example.abys.ui.components.NightTimeline
-import com.example.abys.ui.components.SeasonalParticles
+import com.example.abys.ui.city.CityPickerSheet
 import com.example.abys.ui.components.PrayerBoard
 import com.example.abys.ui.components.TopOverlay
+import com.example.abys.ui.effects.SeasonalParticles
 
 // Импорт для BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -209,13 +210,13 @@ class MainActivity : AppCompatActivity() {
         val cv = ComposeView(this)
         cv.setContent {
             MaterialTheme {
-                com.example.abys.ui.city.CityPickerSheet { picked ->
+                CityPickerSheet(onPick = { picked ->
                     lifecycleScope.launchWhenStarted {
                         SettingsStore.setCity(this@MainActivity, picked)
                     }
                     vm.loadByCity(picked)
                     sheet.dismiss()
-                }
+                })
             }
         }
         sheet.setContentView(cv)


### PR DESCRIPTION
## Summary
- fix the SeasonalParticles import to use the effects package
- import CityPickerSheet directly and pass the onPick lambda explicitly in the manual city dialog

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ec5a437b0c832daed44d04fe8f1350