### PR TITLE
Restore main ViewModel and deduplicate location helper

### DIFF
--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -1,36 +1,156 @@
-package com.example.abys.util   // ← оставьте тот же пакет
+package com.example.abys.logic
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.location.Location
-import android.location.LocationManager
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.abys.net.RetrofitProvider
+import com.example.abys.net.TimingsResponse
+import com.example.abys.util.LocationHelper
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.launch
+import retrofit2.Response
+import java.time.ZoneId
 
-object LocationHelper {
+class MainViewModel(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
 
-    /** Новый универсальный метод — сразу (lat,lon) или null */
-    @SuppressLint("MissingPermission")
-    suspend fun getLastBestLocation(ctx: Context): Pair<Double, Double>? =
-        withContext(Dispatchers.IO) {
-            getLastKnownLocation(ctx)?.let { it.latitude to it.longitude }
+    private val api = RetrofitProvider.aladhan
+
+    private val _city = MutableLiveData<String?>()
+    val city: LiveData<String?> = _city
+
+    private val _timings = MutableLiveData<UiTimings?>()
+    val timings: LiveData<UiTimings?> = _timings
+
+    private val _school = MutableLiveData(0)
+    val school: LiveData<Int> = _school
+
+    private val _hijri = MutableLiveData<String?>()
+    val hijri: LiveData<String?> = _hijri
+
+    private val _error = MutableLiveData<String?>()
+    val error: LiveData<String?> = _error
+
+    private var lastLocation: Pair<Double, Double>? = null
+    private var lastCity: String? = null
+
+    fun loadSavedSchool(ctx: Context) {
+        viewModelScope.launch(ioDispatcher) {
+            val savedSchool = SettingsStore.getSchool(ctx)
+            _school.postValue(savedSchool)
+
+            val savedCity = SettingsStore.getCity(ctx)
+            lastCity = savedCity
+            _city.postValue(savedCity)
+        }
+    }
+
+    fun setSchool(school: Int, reload: Boolean, ctx: Context) {
+        viewModelScope.launch(ioDispatcher) {
+            SettingsStore.setSchool(ctx, school)
+            _school.postValue(school)
+
+            if (reload) {
+                when {
+                    lastLocation != null -> {
+                        val (lat, lon) = lastLocation!!
+                        loadTimingsForLocation(lat, lon, null)
+                    }
+                    lastCity != null -> {
+                        val city = lastCity!!
+                        loadTimingsFromFetcher(city) { school ->
+                            api.timingsByCity(city, DEFAULT_COUNTRY, school = school)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun loadByLocation(ctx: Context) {
+        viewModelScope.launch(ioDispatcher) {
+            val loc = LocationHelper.getLastBestLocation(ctx)
+            if (loc == null) {
+                _error.postValue("location_unavailable")
+                return@launch
+            }
+            lastLocation = loc
+            lastCity = null
+            loadTimingsForLocation(loc.first, loc.second, null)
+        }
+    }
+
+    fun loadByCity(cityName: String, country: String = DEFAULT_COUNTRY) {
+        viewModelScope.launch(ioDispatcher) {
+            lastCity = cityName
+            lastLocation = null
+            loadTimingsFromFetcher(cityName) { school ->
+                api.timingsByCity(cityName, country, school = school)
+            }
+        }
+    }
+
+    private suspend fun loadTimingsForLocation(
+        latitude: Double,
+        longitude: Double,
+        cityName: String?
+    ) {
+        loadTimingsFromFetcher(cityName) { school ->
+            api.timings(latitude, longitude, school = school)
+        }
+    }
+
+    private suspend fun loadTimingsFromFetcher(
+        cityName: String?,
+        fetcher: suspend (Int) -> Response<TimingsResponse>
+    ) {
+        val std = runCatching { fetcher(0) }.getOrElse { throwable ->
+            _error.postValue(throwable.message)
+            return
+        }
+        val han = runCatching { fetcher(1) }.getOrElse { throwable ->
+            _error.postValue(throwable.message)
+            return
         }
 
-    /* ------------ ↓ совместимость со старым кодом ↓ ------------ */
+        val stdData = std.body()?.data
+        val hanData = han.body()?.data
+        if (!std.isSuccessful || !han.isSuccessful || stdData == null || hanData == null) {
+            _error.postValue("api_error")
+            return
+        }
 
-    /** Старая сигнатура, которую ждёт MainViewModel */
-    @SuppressLint("MissingPermission")
-    fun getLastKnownLocation(ctx: Context): Location? {
-        val lm = ctx.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-        val providers = listOf(
-            LocationManager.GPS_PROVIDER,
-            LocationManager.NETWORK_PROVIDER,
-            LocationManager.PASSIVE_PROVIDER
-        ).filter { lm.isProviderEnabled(it) }
+        val zoneId = runCatching { ZoneId.of(stdData.meta.timezone) }.getOrElse { ZoneId.systemDefault() }
+        val timings = UiTimings(
+            fajr = stdData.timings.Fajr,
+            sunrise = stdData.timings.Sunrise,
+            dhuhr = stdData.timings.Dhuhr,
+            asrStd = stdData.timings.Asr,
+            asrHan = hanData.timings.Asr,
+            maghrib = stdData.timings.Maghrib,
+            isha = stdData.timings.Isha,
+            tz = zoneId
+        )
+        _timings.postValue(timings)
 
-        // выбираем наиболее точный lastKnownLocation
-        return providers
-            .mapNotNull { lm.getLastKnownLocation(it) }
-            .minByOrNull { it.accuracy }   // accuracy: меньше = лучше
+        val hijriInfo = stdData.date.hijri
+        _hijri.postValue(
+            hijriInfo?.let { info ->
+                listOfNotNull(info.date, info.month?.en, info.year)
+                    .joinToString(separator = " ")
+            }
+        )
+
+        cityName?.let { name ->
+            _city.postValue(name)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_COUNTRY = "Kazakhstan"
     }
 }

--- a/app/src/main/java/com/example/abys/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.abys.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -9,44 +11,41 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.example.abys.R
+import com.example.abys.logic.CitySearchViewModel
 import com.example.abys.logic.MainViewModel
 import com.example.abys.logic.SettingsStore
 import com.example.abys.logic.TimeHelper
+import com.example.abys.ui.background.SlideshowBackground
+import com.example.abys.ui.city.CityPickerSheet
+import com.example.abys.ui.components.GlassCard
+import com.example.abys.ui.components.NightTimeline
+import com.example.abys.ui.components.PrayerBoard
+import com.example.abys.ui.components.TopOverlay
+import com.example.abys.ui.effects.SeasonalParticles
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.card.MaterialCardView
 import java.time.Duration
 
-// Compose импорты
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.platform.ComposeView
-import com.example.abys.ui.background.SlideshowBackground
-import com.example.abys.ui.components.GlassCard
-import com.example.abys.ui.components.NightTimeline
-import com.example.abys.ui.city.CityPickerSheet
-import com.example.abys.ui.components.PrayerBoard
-import com.example.abys.ui.components.TopOverlay
-import com.example.abys.ui.effects.SeasonalParticles
-
-// Импорт для BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialog
-
 class MainActivity : AppCompatActivity() {
 
     private lateinit var vm: MainViewModel
+    private lateinit var cityVm: CitySearchViewModel
     private lateinit var tvCity: TextView
     private lateinit var tvDate: TextView
     private lateinit var tvNextPrayer: TextView
@@ -74,16 +73,12 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-class MainActivity : ComponentActivity() {
-
-    /** создаём ViewModel “по-классически”, без compose-экстеншенов */
-    private val vm: PrayerViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         vm = ViewModelProvider(this)[MainViewModel::class.java]
+        cityVm = ViewModelProvider(this)[CitySearchViewModel::class.java]
 
         tvCity = findViewById(R.id.tvCity)
         tvDate = findViewById(R.id.tvDate)
@@ -219,7 +214,7 @@ class MainActivity : ComponentActivity() {
                     }
                     vm.loadByCity(picked)
                     sheet.dismiss()
-                })
+                }, vm = cityVm)
             }
         }
         sheet.setContentView(cv)

--- a/app/src/main/java/com/example/abys/util/LocationHelper.kt
+++ b/app/src/main/java/com/example/abys/util/LocationHelper.kt
@@ -13,17 +13,21 @@ object LocationHelper {
     @SuppressLint("MissingPermission")
     suspend fun getLastBestLocation(ctx: Context): Pair<Double, Double>? =
         withContext(Dispatchers.IO) {
-            val lm = ctx.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-            val providers = listOf(
-                LocationManager.GPS_PROVIDER,
-                LocationManager.NETWORK_PROVIDER,
-                LocationManager.PASSIVE_PROVIDER
-            ).filter { lm.isProviderEnabled(it) }
-
-            val loc: Location? = providers
-                .mapNotNull { lm.getLastKnownLocation(it) }
-                .maxByOrNull { it.accuracy * -1 }  // самая точная
-
-            loc?.let { it.latitude to it.longitude }
+            getLastKnownLocation(ctx)?.let { it.latitude to it.longitude }
         }
+
+    /** Совместимость со старым кодом, ожидающим Location? */
+    @SuppressLint("MissingPermission")
+    fun getLastKnownLocation(ctx: Context): Location? {
+        val lm = ctx.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        val providers = listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+            LocationManager.PASSIVE_PROVIDER
+        ).filter { lm.isProviderEnabled(it) }
+
+        return providers
+            .mapNotNull { lm.getLastKnownLocation(it) }
+            .minByOrNull { it.accuracy }
+    }
 }


### PR DESCRIPTION
## Summary
- recreate the legacy MainViewModel to load prayer timings and manage saved city/school state
- consolidate location helpers into the util module so both LiveData and suspend callers share the same API
- clean MainActivity imports and initialization so it uses the restored view model and passes the city search view model to the picker sheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed2d87b628832d9a9155eece4ef6d2