### PR TITLE
Add JUnit dependencies for Android tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,4 +65,9 @@ dependencies {
 
     // java.time на API 23
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+
+    // Testing
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }


### PR DESCRIPTION
## Summary
- add the JUnit 4 dependency so unit tests can reference org.junit APIs
- add AndroidX instrumentation testing dependencies for the generated instrumentation test class

## Testing
- `./gradlew test` *(fails: Java 17 toolchain is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed35d842f0832db7e5c9465e1ae752