### PR TITLE
Shorten greeting video playback

### DIFF
--- a/app/src/main/java/com/example/abys/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/SplashActivity.kt
@@ -1,7 +1,6 @@
 package com.example.abys.ui
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.media3.common.MediaItem
@@ -21,8 +20,17 @@ class SplashActivity : AppCompatActivity() {
 
         playerView = findViewById(R.id.playerView)        // ← из разметки
 
+        val mediaItem = MediaItem.Builder()
+            .setUri("asset:///greeting.mp4")
+            .setClippingConfiguration(
+                MediaItem.ClippingConfiguration.Builder()
+                    .setEndPositionMs(2000)
+                    .build()
+            )
+            .build()
+
         player = ExoPlayer.Builder(this).build().apply {
-            setMediaItem(MediaItem.fromUri("asset:///greeting.mp4"))
+            setMediaItem(mediaItem)
             prepare()
             playWhenReady = true
             addListener(object : Player.Listener {


### PR DESCRIPTION
## Summary
- clip the splash screen greeting video to two seconds before playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed40b32b80832db15b4e9759a722e1