### PR TITLE
Refine leaves effect visuals

### DIFF
--- a/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
@@ -5,67 +5,55 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.withTransform
 import kotlinx.coroutines.delay
-import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
+
+private val leafRandom = Random(System.currentTimeMillis())
 
 private data class Leaf(
     var x: Float,
     var y: Float,
     var vx: Float,
     var vy: Float,
-    var r: Float,
+    var size: Float,
     var phase: Float,
-    val hue: Float
+    var rotation: Float,
+    var spin: Float,
+    val sway: Float,
+    val bend: Float,
+    val color: Color,
+    val veinColor: Color
 )
 
 @Composable
-fun LeavesEffect(modifier: Modifier = Modifier, density: Float = 0.1f) {
+fun LeavesEffect(modifier: Modifier = Modifier, density: Float = 0.04f) {
     // density ~ доля листьев на 10_000 px^2
     var particles by remember { mutableStateOf<List<Leaf>>(emptyList()) }
     var w by remember { mutableStateOf(0f) }
     var h by remember { mutableStateOf(0f) }
-
-    Canvas(modifier) {
-        if (w != size.width || h != size.height || particles.isEmpty()) {
-            w = size.width; h = size.height
-            val count = ((w * h) / 10000f * density).toInt().coerceAtLeast(12)
-            val rnd = Random(System.currentTimeMillis())
-            particles = List(count) {
-                val r = rnd.nextFloat() * 5f + 2f
-                Leaf(
-                    x = rnd.nextFloat() * w,
-                    y = rnd.nextFloat() * h,
-                    vx = (rnd.nextFloat() - 0.5f) * 0.6f,
-                    vy = (rnd.nextFloat() * 1.2f + 0.6f),
-                    r = r,
-                    phase = rnd.nextFloat() * 6.28f,
-                    hue = 0.11f + rnd.nextFloat() * 0.1f // желто-оранжевая гамма
-                )
-            }
-        }
-
-        drawIntoCanvas {
-            // шаг симуляции ~16мс
-        }
-    }
+    val leafPath = remember { Path() }
 
     LaunchedEffect(w, h) {
         while (true) {
+            if (w == 0f || h == 0f) {
+                delay(32L)
+                continue
+            }
             particles = particles.map { p ->
-                val nx = p.x + p.vx + sin(p.phase) * 0.4f
+                val nx = p.x + p.vx + sin(p.phase) * p.sway
                 val ny = p.y + p.vy
-                var x = nx; var y = ny; var phase = p.phase + 0.04f
-                if (y > h + 20f) {                // респавн сверху
-                    y = -10f
-                    x = Random.nextFloat() * w
+                val phaseRaw = p.phase + 0.035f
+                val phase = if (phaseRaw > TAU) phaseRaw - TAU else phaseRaw
+                val rotation = p.rotation + p.spin
+
+                if (ny > h + 40f || nx < -40f || nx > w + 40f) {
+                    createLeaf(w, h, spawnFromTop = true)
+                } else {
+                    p.copy(x = nx, y = ny, phase = phase, rotation = rotation)
                 }
-                if (x < -20f) x = w + 10f
-                if (x > w + 20f) x = -10f
-                p.copy(x = x, y = y, phase = phase)
             }
             // перерисовать
             // используем recomposition триггер через новое значение
@@ -74,13 +62,92 @@ fun LeavesEffect(modifier: Modifier = Modifier, density: Float = 0.1f) {
     }
 
     Canvas(modifier) {
+        if (size.width == 0f || size.height == 0f) return@Canvas
+
+        if (w != size.width || h != size.height || particles.isEmpty()) {
+            w = size.width; h = size.height
+            val count = ((w * h) / 10000f * density).toInt().coerceAtLeast(6)
+            particles = List(count) { createLeaf(w, h) }
+        }
+
         particles.forEach { p ->
-            // простые кружки (блики листьев), более редкие и хаотичные
-            drawCircle(
-                color = Color(0xFFF2B233),
-                radius = p.r,
-                center = Offset(p.x, p.y)
-            )
+            leafPath.configureLeaf(p.size, p.bend)
+            withTransform({
+                translate(p.x, p.y)
+                rotate(p.rotation)
+            }) {
+                drawPath(path = leafPath, color = p.color)
+                drawLine(
+                    color = p.veinColor,
+                    start = Offset(0f, -p.size * 1.2f),
+                    end = Offset(0f, p.size * 1.1f),
+                    strokeWidth = p.size * 0.12f
+                )
+                val branch = p.size * 0.7f
+                drawLine(
+                    color = p.veinColor.copy(alpha = 0.8f),
+                    start = Offset(0f, -p.size * 0.2f),
+                    end = Offset(branch, p.size * 0.3f),
+                    strokeWidth = p.size * 0.08f
+                )
+                drawLine(
+                    color = p.veinColor.copy(alpha = 0.8f),
+                    start = Offset(0f, p.size * 0.2f),
+                    end = Offset(-branch, p.size * 0.5f),
+                    strokeWidth = p.size * 0.08f
+                )
+            }
         }
     }
+}
+
+private const val TAU = 6.2831855f
+
+private fun createLeaf(width: Float, height: Float, spawnFromTop: Boolean = false): Leaf {
+    val leafSize = leafRandom.nextFloat() * 9f + 6f
+    val hue = 30f + leafRandom.nextFloat() * 25f
+    val saturation = 0.65f + leafRandom.nextFloat() * 0.25f
+    val value = 0.7f + leafRandom.nextFloat() * 0.2f
+    val color = Color.hsv(hue, saturation, value)
+    val veinColor = Color.hsv(hue, saturation * 0.5f, (value * 0.8f).coerceAtMost(1f))
+    val startY = if (spawnFromTop) -leafRandom.nextFloat() * height * 0.3f - 40f else leafRandom.nextFloat() * height
+    return Leaf(
+        x = leafRandom.nextFloat() * width,
+        y = startY,
+        vx = (leafRandom.nextFloat() - 0.5f) * 1.4f,
+        vy = 0.6f + leafRandom.nextFloat() * 1.6f,
+        size = leafSize,
+        phase = leafRandom.nextFloat() * TAU,
+        rotation = leafRandom.nextFloat() * 360f,
+        spin = (leafRandom.nextFloat() - 0.5f) * 1.2f,
+        sway = (0.15f + leafRandom.nextFloat() * 0.35f) * leafSize,
+        bend = (leafRandom.nextFloat() - 0.5f) * 1.2f,
+        color = color,
+        veinColor = veinColor
+    )
+}
+
+private fun Path.configureLeaf(size: Float, bend: Float) {
+    reset()
+    val halfLength = size * 1.4f
+    val halfWidth = size * 0.6f
+    val bendOffset = bend * size * 0.5f
+    moveTo(0f, -halfLength)
+    cubicTo(
+        halfWidth,
+        -halfLength * 0.25f,
+        halfWidth + bendOffset,
+        halfLength * 0.2f,
+        0f,
+        halfLength
+    )
+    cubicTo(
+        -halfWidth + bendOffset,
+        halfLength * 0.2f,
+        -halfWidth,
+        -halfLength * 0.25f,
+        0f,
+        -halfLength
+    )
+    close()
 }


### PR DESCRIPTION
## Summary
- replace circular particles with hand-drawn leaf paths and veins for a more natural fall effect
- randomize sway, spin, bend, and spawn density to make leaves rarer and movement more chaotic
- reuse a single canvas draw to keep particle list updated when the viewport changes

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: toolchain JDK 17 not preinstalled in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7d9f3fa8832da1dcd7616d1b854c