### PR TITLE
Fix carousel snapping

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 @Composable
 fun EffectCarousel(
@@ -211,7 +212,7 @@ fun EffectCarousel(
                     .collectLatest { scrolling ->
                         if (!scrolling) {
                             delay(450)
-                            val center = listCenter.takeIf { it > 0f } ?: return@collect
+                            val center = listCenter.takeIf { it > 0f } ?: return@collectLatest
                             val layoutInfo = state.layoutInfo
                             val visible = layoutInfo.visibleItemsInfo
                             val closest = visible.minByOrNull { info ->
@@ -226,8 +227,9 @@ fun EffectCarousel(
                                 val itemCenterPx = info.offset + info.size / 2f
                                 val delta = itemCenterPx - center
                                 if (abs(delta) > 4f) {
+                                    val desiredOffset = (center - info.size / 2f).roundToInt()
                                     scope.launch {
-                                        state.animateScrollBy(delta)
+                                        state.animateScrollToItem(info.index, scrollOffset = desiredOffset)
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- ensure the scroll snapping coroutine exits correctly when the list center is unavailable
- replace animateScrollBy with animateScrollToItem to compute a centered offset and add missing import

## Testing
- ./gradlew -p app assembleDebug *(fails: missing Java 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9a525094832daaaf806fca318fd4