### PR TITLE
Improve theme carousel interactions and accessibility

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -1,9 +1,9 @@
 package com.example.abys.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -20,32 +20,42 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import com.example.abys.R
 import com.example.abys.ui.effects.ThemeSpec
 import kotlinx.coroutines.delay
@@ -54,6 +64,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EffectCarousel(
     themes: List<ThemeSpec>,
@@ -61,15 +72,19 @@ fun EffectCarousel(
     collapsed: Boolean,
     onCollapsedChange: (Boolean) -> Unit,
     onThemeSnapped: (ThemeSpec) -> Unit,
-    onDoubleTapApply: (ThemeSpec) -> Unit
+    onDoubleTapApply: (ThemeSpec) -> Unit,
+    onTapCenterApply: (ThemeSpec) -> Unit
 ) {
     val state = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    val haptics = LocalHapticFeedback.current
 
     val alpha by animateFloatAsState(targetValue = if (collapsed) 0.35f else 1f, label = "carAlpha")
     val targetHeight = if (collapsed) 72.dp else 132.dp
     val height by animateDpAsState(targetValue = targetHeight, label = "carHeight")
     val updatedOnSnapped by rememberUpdatedState(onThemeSnapped)
+    val updatedOnDoubleTap by rememberUpdatedState(onDoubleTapApply)
+    val updatedOnTapApply by rememberUpdatedState(onTapCenterApply)
 
     if (themes.isEmpty()) {
         return
@@ -80,115 +95,222 @@ fun EffectCarousel(
             .fillMaxWidth()
             .height(height)
             .alpha(alpha)
-            .animateContentSize()
             .pointerInput(collapsed) {
                 detectTapGestures(onTap = { if (collapsed) onCollapsedChange(false) })
             }
     ) {
         if (collapsed) {
+            val selectedTheme = remember(selectedThemeId, themes) {
+                themes.firstOrNull { it.id == selectedThemeId } ?: themes.first()
+            }
             Box(
                 Modifier
                     .align(Alignment.Center)
-                    .size(64.dp)
-                    .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0x44000000))
-            )
-        } else {
-            var listCenter by remember { mutableStateOf(0f) }
-            var snappedIndex by remember { mutableStateOf(0) }
-            var showHint by remember { mutableStateOf(true) }
-
-            LazyRow(
-                state = state,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = 8.dp)
-                    .onGloballyPositioned { coords ->
-                        listCenter = coords.size.width / 2f
-                    },
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                contentPadding = PaddingValues(horizontal = 32.dp)
+                    .size(68.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .border(
+                        width = 2.dp,
+                        brush = Brush.verticalGradient(
+                            listOf(Color.White.copy(alpha = 0.35f), Color.White.copy(alpha = 0.12f))
+                        ),
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                    .background(Color.Black.copy(alpha = 0.35f))
             ) {
-                itemsIndexed(themes) { idx, spec ->
-                    var itemCenter by remember { mutableStateOf(0f) }
+                Image(
+                    painter = painterResource(id = selectedTheme.thumbRes),
+                    contentDescription = stringResource(id = selectedTheme.titleRes),
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        } else {
+            var snappedIndex by remember { mutableStateOf(0) }
+            var showHint by rememberSaveable { mutableStateOf(true) }
 
-                    val scale = remember(itemCenter, listCenter) {
-                        if (listCenter <= 0f) 0.92f else {
-                            val distancePx = abs(itemCenter - listCenter)
-                            val influence = 1f - (distancePx / (listCenter * 1.2f)).coerceIn(0f, 1f)
-                            0.92f + influence * 0.48f
+            fun applyAndCollapse(spec: ThemeSpec, callback: (ThemeSpec) -> Unit) {
+                showHint = false
+                callback(spec)
+                onCollapsedChange(true)
+                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+            }
+
+            val viewportCenter by remember {
+                derivedStateOf {
+                    val layoutInfo = state.layoutInfo
+                    (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
+                }
+            }
+
+            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                LazyRow(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    contentPadding = PaddingValues(horizontal = 32.dp)
+                ) {
+                    itemsIndexed(
+                        items = themes,
+                        key = { _, spec -> spec.id }
+                    ) { idx, spec ->
+                        val itemInfo by remember {
+                            derivedStateOf {
+                                state.layoutInfo.visibleItemsInfo.firstOrNull { it.index == idx }
+                            }
                         }
-                    }
-
-                    Box(
-                        Modifier
-                            .size(96.dp)
-                            .onGloballyPositioned { coords ->
-                                val width = coords.size.width
-                                itemCenter = coords.positionInParent().x + width / 2f
+                        val scale by remember {
+                            derivedStateOf {
+                                val info = itemInfo
+                                val center = viewportCenter
+                                if (info == null || center <= 0f) {
+                                    0.92f
+                                } else {
+                                    val itemCenter = info.offset + info.size / 2f
+                                    val distancePx = abs(itemCenter - center)
+                                    val influence = 1f - (distancePx / (center * 1.2f)).coerceIn(0f, 1f)
+                                    0.92f + influence * 0.48f
+                                }
                             }
-                            .scale(scale)
-                            .clip(RoundedCornerShape(20.dp))
-                            .border(
-                                width = if (scale > 1.25f) 3.dp else 1.dp,
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color(0x55FFFFFF),
-                                        Color(0x11FFFFFF)
-                                    )
-                                ),
-                                shape = RoundedCornerShape(20.dp)
-                            )
-                            .background(Color.Black.copy(alpha = 0.25f))
-                            .pointerInput(Unit) {
-                                detectTapGestures(
-                                    onDoubleTap = {
-                                        onDoubleTapApply(spec)
-                                        onCollapsedChange(true)
-                                        showHint = false
-                                        scope.launch {
-                                            state.animateScrollToItem(idx)
-                                        }
-                                    }
-                                )
-                            }
-                    ) {
-                        Image(
-                            painter = painterResource(id = spec.thumbRes),
-                            contentDescription = stringResource(id = spec.titleRes),
-                            modifier = Modifier.fillMaxSize()
+                        }
+                        val borderWidth by animateDpAsState(
+                            targetValue = if (scale > 1.18f) 3.dp else 1.dp,
+                            label = "borderWidth"
                         )
-                        if (spec.id == selectedThemeId) {
-                            Box(
-                                Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(6.dp)
-                                    .size(18.dp)
-                                    .clip(RoundedCornerShape(50))
-                                    .background(Color(0xAA1B5E20)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = "\u2713",
-                                    color = Color.White,
-                                    style = MaterialTheme.typography.labelSmall
-                                )
+                        val isCentered by remember {
+                            derivedStateOf {
+                                val info = itemInfo
+                                val center = viewportCenter
+                                if (info == null) {
+                                    false
+                                } else {
+                                    val itemCenter = info.offset + info.size / 2f
+                                    abs(itemCenter - center) < info.size * 0.25f
+                                }
                             }
                         }
+                        val title = stringResource(id = spec.titleRes)
+
                         Box(
                             Modifier
-                                .align(Alignment.BottomCenter)
-                                .background(Color.Black.copy(alpha = 0.35f))
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp)
+                                .size(96.dp)
+                                .graphicsLayer {
+                                    scaleX = scale
+                                    scaleY = scale
+                                    shadowElevation = if (scale > 1.15f) 14f else 0f
+                                }
+                                .clip(RoundedCornerShape(20.dp))
+                                .border(
+                                    width = borderWidth,
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color(0x66FFFFFF),
+                                            Color(0x22FFFFFF)
+                                        )
+                                    ),
+                                    shape = RoundedCornerShape(20.dp)
+                                )
+                                .background(Color.Black.copy(alpha = 0.25f))
+                                .pointerInput(idx, isCentered, viewportCenter, itemInfo?.offset ?: 0, itemInfo?.size ?: 0) {
+                                    detectTapGestures(
+                                        onTap = {
+                                            if (!isCentered) {
+                                                scope.launch {
+                                                    itemInfo?.let { info ->
+                                                        val desiredOffset = (viewportCenter - info.size / 2f).roundToInt()
+                                                        state.animateScrollToItem(idx, scrollOffset = desiredOffset)
+                                                    }
+                                                }
+                                            } else {
+                                                applyAndCollapse(spec, updatedOnTapApply)
+                                            }
+                                        },
+                                        onDoubleTap = {
+                                            if (state.isScrollInProgress) {
+                                                return@detectTapGestures
+                                            }
+                                            scope.launch {
+                                                val info = itemInfo
+                                                val desiredOffset = if (info != null && viewportCenter > 0f) {
+                                                    (viewportCenter - info.size / 2f).roundToInt()
+                                                } else {
+                                                    0
+                                                }
+                                                state.animateScrollToItem(idx, scrollOffset = desiredOffset)
+                                                applyAndCollapse(spec, updatedOnDoubleTap)
+                                            }
+                                        }
+                                    )
+                                }
+                                .semantics(mergeDescendants = true) {
+                                    contentDescription = stringResource(
+                                        id = R.string.theme_apply_talkback,
+                                        title
+                                    )
+                                    onClick(label = stringResource(id = R.string.theme_apply_action, title)) {
+                                        if (!isCentered) return@onClick false
+                                        applyAndCollapse(spec, updatedOnTapApply)
+                                        true
+                                    }
+                                    customActions = listOf(
+                                        CustomAccessibilityAction(
+                                            label = stringResource(id = R.string.theme_apply_double_tap, title)
+                                        ) {
+                                            if (state.isScrollInProgress) return@CustomAccessibilityAction false
+                                            scope.launch {
+                                                val info = itemInfo
+                                                val desiredOffset = if (info != null && viewportCenter > 0f) {
+                                                    (viewportCenter - info.size / 2f).roundToInt()
+                                                } else {
+                                                    0
+                                                }
+                                                state.animateScrollToItem(idx, scrollOffset = desiredOffset)
+                                                applyAndCollapse(spec, updatedOnDoubleTap)
+                                            }
+                                            true
+                                        }
+                                    )
+                                    this.role = Role.Button
+                                }
                         ) {
-                            Text(
-                                text = stringResource(id = spec.titleRes),
-                                modifier = Modifier.align(Alignment.Center),
-                                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
-                                color = Color.White
+                            Image(
+                                painter = painterResource(id = spec.thumbRes),
+                                contentDescription = null,
+                                modifier = Modifier.fillMaxSize()
                             )
+                            if (spec.id == selectedThemeId) {
+                                Box(
+                                    Modifier
+                                        .align(Alignment.TopEnd)
+                                        .padding(6.dp)
+                                        .size(22.dp)
+                                        .clip(RoundedCornerShape(50))
+                                        .background(Color(0xCC1B5E20)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "\u2713",
+                                        color = Color.White,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontSize = 14.sp
+                                    )
+                                }
+                            }
+                            Box(
+                                Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .background(Color.Black.copy(alpha = 0.35f))
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp)
+                            ) {
+                                Text(
+                                    text = title,
+                                    modifier = Modifier.align(Alignment.Center),
+                                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                                    color = Color.White
+                                )
+                            }
                         }
                     }
                 }
@@ -212,7 +334,9 @@ fun EffectCarousel(
                     .collectLatest { scrolling ->
                         if (!scrolling) {
                             delay(450)
-                            val center = listCenter.takeIf { it > 0f } ?: return@collectLatest
+                            val layoutInfo = state.layoutInfo
+                            val center = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
+                            if (center <= 0f) return@collectLatest
                             val layoutInfo = state.layoutInfo
                             val visible = layoutInfo.visibleItemsInfo
                             val closest = visible.minByOrNull { info ->

--- a/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.hapticfeedback.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
@@ -90,7 +88,6 @@ fun HomeScreen(viewModel: PrayerViewModel) {
     var windPhase by remember { mutableStateOf(0f) }
     var applyFlash by remember { mutableStateOf(false) }
     val flashAlpha by animateFloatAsState(if (applyFlash) 0.3f else 0f, label = "applyFlash")
-    val haptics = LocalHapticFeedback.current
     val scope = rememberCoroutineScope()
 
     val ctxState = LocalContext.current
@@ -202,20 +199,22 @@ fun HomeScreen(viewModel: PrayerViewModel) {
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 12.dp)
         ) {
+            val applyTheme: (ThemeSpec) -> Unit = { spec ->
+                appliedTheme = spec
+                carouselCollapsed = true
+                focusedTheme = spec
+                applyFlash = true
+                scope.launch { SettingsStore.setThemeId(ctxState, spec.id) }
+            }
+
             EffectCarousel(
                 themes = themes,
                 selectedThemeId = appliedTheme.id,
                 collapsed = carouselCollapsed,
                 onCollapsedChange = { carouselCollapsed = it },
                 onThemeSnapped = { focusedTheme = it },
-                onDoubleTapApply = { spec ->
-                    appliedTheme = spec
-                    carouselCollapsed = true
-                    focusedTheme = spec
-                    applyFlash = true
-                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                    scope.launch { SettingsStore.setThemeId(ctxState, spec.id) }
-                }
+                onDoubleTapApply = applyTheme,
+                onTapCenterApply = applyTheme
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="theme_active_label">Тема: %1$s</string>
     <string name="theme_preview_label">Предпросмотр: %1$s</string>
     <string name="theme_apply_hint">Двойной тап — применить тему</string>
+    <string name="theme_apply_talkback">Дважды коснитесь, чтобы применить тему %1$s</string>
+    <string name="theme_apply_action">Применить тему %1$s</string>
+    <string name="theme_apply_double_tap">Двойной тап — применить тему %1$s</string>
 
     <!-- Намазы -->
     <string name="prayer_fajr">Fajr</string>


### PR DESCRIPTION
## Summary
- add stable keys, derived scaling and overscroll tweaks to smooth the theme carousel experience
- support single-tap apply with shared haptics/semantics and center preview when collapsed
- surface new accessibility strings and reuse the apply pipeline in HomeScreen

## Testing
- ./gradlew :app:assembleDebug *(fails: missing JDK 17 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9c5eabfc832dada137dcabb1f091