### PR TITLE
Refine leaves effect animation loop

### DIFF
--- a/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
@@ -1,7 +1,13 @@
 package com.example.abys.ui.effects
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -9,24 +15,52 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.withTransform
 import kotlinx.coroutines.delay
 import kotlin.math.sin
+import kotlin.math.roundToInt
 import kotlin.random.Random
 
 private val leafRandom = Random(System.currentTimeMillis())
 
-private data class Leaf(
-    var x: Float,
-    var y: Float,
-    var vx: Float,
-    var vy: Float,
-    var size: Float,
-    var phase: Float,
-    var rotation: Float,
-    var spin: Float,
-    val sway: Float,
-    val bend: Float,
-    val color: Color,
-    val veinColor: Color
+private class Leaf {
+    var x: Float = 0f
+    var y: Float = 0f
+    var size: Float = 0f
+    var bend: Float = 0f
+    var phase: Float = 0f
+    var rotation: Float = 0f
+
+    var baseVx: Float = 0f
+    var baseVy: Float = 0f
+    var baseSway: Float = 0f
+    var baseSpinSpeed: Float = 0f
+    var basePhaseSpeed: Float = 0f
+
+    var bodyColor: Color = Color.Transparent
+    var veinColorMain: Color = Color.Transparent
+    var veinColorBranch: Color = Color.Transparent
+
+    val path: Path = Path()
+}
+
+private data class LeafLayer(
+    val sizeMultiplier: Float,
+    val speedMultiplier: Float,
+    val swayMultiplier: Float,
+    val alphaMultiplier: Float
 )
+
+private val leafLayers = arrayOf(
+    LeafLayer(sizeMultiplier = 1.25f, speedMultiplier = 1.3f, swayMultiplier = 1.2f, alphaMultiplier = 1f),
+    LeafLayer(sizeMultiplier = 1f, speedMultiplier = 1f, swayMultiplier = 1f, alphaMultiplier = 0.85f),
+    LeafLayer(sizeMultiplier = 0.8f, speedMultiplier = 0.75f, swayMultiplier = 0.7f, alphaMultiplier = 0.7f)
+)
+
+private const val TAU = 6.2831855f
+private const val FRAME_DELAY_MS = 16L
+private const val FRAME_DT = 1f / 60f
+private const val BASELINE_AREA = 1080f * 1920f
+private const val DEFAULT_DENSITY = 0.12f
+private const val MIN_LEAF_COUNT = 12f
+private const val MAX_LEAF_COUNT = 80f
 
 @Composable
 fun LeavesEffect(
@@ -34,110 +68,210 @@ fun LeavesEffect(
     params: LeavesParams,
     intensity: Float
 ) {
-    val density = (params.density * intensity).coerceAtLeast(0.02f)
-    var particles by remember { mutableStateOf<List<Leaf>>(emptyList()) }
-    var w by remember { mutableStateOf(0f) }
-    var h by remember { mutableStateOf(0f) }
-    val leafPath = remember { Path() }
+    val leaves = remember { mutableStateListOf<Leaf>() }
+    var canvasWidth by remember { mutableStateOf(0f) }
+    var canvasHeight by remember { mutableStateOf(0f) }
+    var frameTick by remember { mutableStateOf(0) }
+    var currentIntensity by remember { mutableStateOf(intensity) }
+    var previousParams by remember { mutableStateOf(params) }
 
-    LaunchedEffect(w, h) {
+    LaunchedEffect(intensity) {
+        currentIntensity = intensity.coerceIn(0f, 1f)
+    }
+
+    LaunchedEffect(canvasWidth, canvasHeight, params, currentIntensity) {
+        if (canvasWidth == 0f || canvasHeight == 0f) return@LaunchedEffect
+        val desiredCount = computeLeafCount(canvasWidth, canvasHeight, params, currentIntensity)
+        adjustLeafCount(leaves, desiredCount, canvasWidth, canvasHeight, params)
+
+        if (previousParams != params) {
+            leaves.forEach { leaf ->
+                leaf.reset(canvasWidth, canvasHeight, params)
+            }
+            previousParams = params
+        }
+    }
+
+    LaunchedEffect(canvasWidth, canvasHeight, params, currentIntensity) {
+        var windPhase = leafRandom.nextFloat() * TAU
+        var gustTimer = 0f
+        var gustDuration = randomRange(0.8f, 1.2f)
+        var gustStrength = 0f
+        var gustTarget = 0f
+        val windPeriod = randomRange(6f, 10f)
+
         while (true) {
-            if (w == 0f || h == 0f) {
-                delay(32L)
+            if (canvasWidth == 0f || canvasHeight == 0f || leaves.isEmpty()) {
+                delay(FRAME_DELAY_MS)
                 continue
             }
-            particles = particles.map { p ->
-                val nx = p.x + p.vx + sin(p.phase) * p.sway
-                val ny = p.y + p.vy
-                val phaseRaw = p.phase + 0.035f
-                val phase = if (phaseRaw > TAU) phaseRaw - TAU else phaseRaw
-                val rotation = p.rotation + p.spin
 
-                if (ny > h + 40f || nx < -40f || nx > w + 40f) {
-                    createLeaf(w, h, params, intensity, spawnFromTop = true)
-                } else {
-                    p.copy(x = nx, y = ny, phase = phase, rotation = rotation)
+            val speedScale = 0.7f + 0.6f * currentIntensity
+            val swayScale = 0.8f + 0.5f * currentIntensity
+            val driftScale = 0.6f + 0.5f * currentIntensity
+            val spinScale = 0.5f + 0.7f * currentIntensity
+
+            windPhase += FRAME_DT * TAU / windPeriod
+            if (windPhase > TAU) windPhase -= TAU
+
+            gustTimer += FRAME_DT
+            if (gustTimer >= gustDuration) {
+                gustTimer = 0f
+                gustDuration = randomRange(0.8f, 1.2f)
+                gustTarget = randomRange(-1f, 1f) * params.driftX * 120f
+            }
+            gustStrength += (gustTarget - gustStrength) * 0.08f
+
+            val baseWind = sin(windPhase) * params.driftX * 42f
+            val windX = (baseWind + gustStrength) * (0.7f + 0.6f * currentIntensity)
+
+            leaves.forEach { leaf ->
+                val vx = leaf.baseVx * driftScale
+                val vy = leaf.baseVy * speedScale
+                val swayVelocity = leaf.baseSway * swayScale
+                val spinSpeed = leaf.baseSpinSpeed * spinScale
+
+                leaf.phase += leaf.basePhaseSpeed * FRAME_DT
+                if (leaf.phase > TAU) leaf.phase -= TAU
+
+                val swayOffset = sin(leaf.phase) * swayVelocity
+
+                leaf.x += (vx + swayOffset + windX) * FRAME_DT
+                leaf.y += vy * FRAME_DT
+                leaf.rotation += spinSpeed * FRAME_DT
+
+                if (leaf.rotation > 360f) {
+                    leaf.rotation -= 360f
+                } else if (leaf.rotation < -360f) {
+                    leaf.rotation += 360f
+                }
+
+                if (leaf.y > canvasHeight + 40f || leaf.x < -40f || leaf.x > canvasWidth + 40f) {
+                    leaf.reset(canvasWidth, canvasHeight, params, spawnFromTop = true)
                 }
             }
-            // перерисовать
-            // используем recomposition триггер через новое значение
-            delay(16L)
+
+            frameTick++
+            delay(FRAME_DELAY_MS)
         }
     }
 
     Canvas(modifier) {
-        if (size.width == 0f || size.height == 0f) return@Canvas
-
-        if (w != size.width || h != size.height || particles.isEmpty()) {
-            w = size.width; h = size.height
-            val areaFactor = (w * h) / (1080f * 1920f)
-            val baseCount = ((w * h) / 10000f * density).toInt()
-            val capped = (baseCount * areaFactor.coerceAtMost(1.4f)).toInt()
-            val count = capped.coerceIn(8, 60)
-            particles = List(count) { createLeaf(w, h, params, intensity) }
+        if (size.width == 0f || size.height == 0f) {
+            canvasWidth = 0f
+            canvasHeight = 0f
+            return@Canvas
         }
 
-        particles.forEach { p ->
-            leafPath.configureLeaf(p.size, p.bend)
+        if (canvasWidth != size.width || canvasHeight != size.height) {
+            canvasWidth = size.width
+            canvasHeight = size.height
+        }
+
+        // читать frameTick, чтобы Canvas перерисовывался
+        frameTick
+
+        leaves.forEach { leaf ->
             withTransform({
-                translate(p.x, p.y)
-                rotate(p.rotation)
+                translate(leaf.x, leaf.y)
+                rotate(leaf.rotation)
             }) {
-                drawPath(path = leafPath, color = p.color)
+                drawPath(path = leaf.path, color = leaf.bodyColor)
                 drawLine(
-                    color = p.veinColor,
-                    start = Offset(0f, -p.size * 1.2f),
-                    end = Offset(0f, p.size * 1.1f),
-                    strokeWidth = p.size * 0.12f
+                    color = leaf.veinColorMain,
+                    start = Offset(0f, -leaf.size * 1.2f),
+                    end = Offset(0f, leaf.size * 1.1f),
+                    strokeWidth = leaf.size * 0.12f
                 )
-                val branch = p.size * 0.7f
+                val branch = leaf.size * 0.7f
+                val branchStroke = leaf.size * 0.08f
                 drawLine(
-                    color = p.veinColor.copy(alpha = 0.8f),
-                    start = Offset(0f, -p.size * 0.2f),
-                    end = Offset(branch, p.size * 0.3f),
-                    strokeWidth = p.size * 0.08f
+                    color = leaf.veinColorBranch,
+                    start = Offset(0f, -leaf.size * 0.2f),
+                    end = Offset(branch, leaf.size * 0.3f),
+                    strokeWidth = branchStroke
                 )
                 drawLine(
-                    color = p.veinColor.copy(alpha = 0.8f),
-                    start = Offset(0f, p.size * 0.2f),
-                    end = Offset(-branch, p.size * 0.5f),
-                    strokeWidth = p.size * 0.08f
+                    color = leaf.veinColorBranch,
+                    start = Offset(0f, leaf.size * 0.2f),
+                    end = Offset(-branch, leaf.size * 0.5f),
+                    strokeWidth = branchStroke
                 )
             }
         }
     }
 }
 
-private const val TAU = 6.2831855f
-
-private fun createLeaf(
+private fun computeLeafCount(
     width: Float,
     height: Float,
     params: LeavesParams,
-    intensity: Float,
+    intensity: Float
+): Int {
+    val areaScale = (width * height) / BASELINE_AREA
+    val densityScale = (params.density.coerceAtLeast(0.01f) / DEFAULT_DENSITY).coerceAtLeast(0.2f)
+    val minCount = (MIN_LEAF_COUNT * densityScale).coerceAtLeast(4f)
+    val maxCount = (MAX_LEAF_COUNT * densityScale)
+    val baseCount = lerp(minCount, maxCount, intensity.coerceIn(0f, 1f))
+    val scaled = (baseCount * areaScale).roundToInt()
+    val scaledMax = (maxCount * areaScale).roundToInt().coerceAtLeast(4)
+    return scaled.coerceIn(4, scaledMax)
+}
+
+private fun adjustLeafCount(
+    leaves: MutableList<Leaf>,
+    desiredCount: Int,
+    width: Float,
+    height: Float,
+    params: LeavesParams
+) {
+    if (leaves.size > desiredCount) {
+        while (leaves.size > desiredCount) {
+            leaves.removeAt(leaves.lastIndex)
+        }
+    } else if (leaves.size < desiredCount) {
+        repeat(desiredCount - leaves.size) {
+            leaves += Leaf().apply {
+                reset(width, height, params)
+            }
+        }
+    }
+}
+
+private fun Leaf.reset(
+    width: Float,
+    height: Float,
+    params: LeavesParams,
     spawnFromTop: Boolean = false
-): Leaf {
-    val leafSize = leafRandom.nextFloat() * 9f + 6f
+) {
+    val layerIndex = leafRandom.nextInt(leafLayers.size)
+    val layer = leafLayers[layerIndex]
+
+    val baseSize = 6f + leafRandom.nextFloat() * 9f
+    size = baseSize * layer.sizeMultiplier
+    bend = (leafRandom.nextFloat() - 0.5f) * 1.2f
+    path.configureLeaf(size, bend)
+
     val hue = 30f + leafRandom.nextFloat() * 25f
     val saturation = 0.65f + leafRandom.nextFloat() * 0.25f
     val value = 0.7f + leafRandom.nextFloat() * 0.2f
-    val color = Color.hsv(hue, saturation, value)
-    val veinColor = Color.hsv(hue, saturation * 0.5f, (value * 0.8f).coerceAtMost(1f))
-    val startY = if (spawnFromTop) -leafRandom.nextFloat() * height * 0.3f - 40f else leafRandom.nextFloat() * height
-    return Leaf(
-        x = leafRandom.nextFloat() * width,
-        y = startY,
-        vx = (leafRandom.nextFloat() - 0.5f) * params.driftX * 1.2f,
-        vy = (params.speedY * intensity * 0.8f) + leafRandom.nextFloat() * params.speedY,
-        size = leafSize,
-        phase = leafRandom.nextFloat() * TAU,
-        rotation = leafRandom.nextFloat() * 360f,
-        spin = (leafRandom.nextFloat() - 0.5f) * 1.2f,
-        sway = (0.15f + leafRandom.nextFloat() * 0.35f) * leafSize,
-        bend = (leafRandom.nextFloat() - 0.5f) * 1.2f,
-        color = color,
-        veinColor = veinColor
-    )
+    val baseColor = Color.hsv(hue, saturation, value)
+    val veinBase = Color.hsv(hue, saturation * 0.5f, (value * 0.8f).coerceAtMost(1f))
+    bodyColor = baseColor.copy(alpha = baseColor.alpha * layer.alphaMultiplier)
+    veinColorMain = veinBase.copy(alpha = veinBase.alpha * layer.alphaMultiplier)
+    veinColorBranch = veinColorMain.copy(alpha = veinColorMain.alpha * 0.75f)
+
+    x = leafRandom.nextFloat() * width
+    y = if (spawnFromTop) -leafRandom.nextFloat() * height * 0.3f - 40f else leafRandom.nextFloat() * height
+
+    baseVx = (leafRandom.nextFloat() - 0.5f) * params.driftX * 1.2f * 60f * layer.speedMultiplier
+    baseVy = ((params.speedY * 0.8f) + leafRandom.nextFloat() * params.speedY) * 60f * layer.speedMultiplier
+    baseSway = ((0.15f + leafRandom.nextFloat() * 0.35f) * size) * 60f * layer.swayMultiplier
+    baseSpinSpeed = ((leafRandom.nextFloat() - 0.5f) * 1.2f) * 60f
+    basePhaseSpeed = (1.5f + leafRandom.nextFloat() * 2.2f)
+
+    phase = leafRandom.nextFloat() * TAU
+    rotation = leafRandom.nextFloat() * 360f
 }
 
 private fun Path.configureLeaf(size: Float, bend: Float) {
@@ -163,4 +297,12 @@ private fun Path.configureLeaf(size: Float, bend: Float) {
         -halfLength
     )
     close()
+}
+
+private fun randomRange(start: Float, end: Float): Float {
+    return start + leafRandom.nextFloat() * (end - start)
+}
+
+private fun lerp(start: Float, stop: Float, amount: Float): Float {
+    return start + (stop - start) * amount
 }


### PR DESCRIPTION
## Summary
- refactor `LeavesEffect` to update leaf particles in place and cache their geometry
- add layered wind, per-second physics, and intensity-aware scaling for smoother animation
- precompute per-leaf colors and counts to remove per-frame allocations and stabilize density

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9fd5d7c8832d883e6411ca3b648b