### PR TITLE
Refine theme effect specs and defaults

### DIFF
--- a/app/src/main/java/com/example/abys/ui/effects/ThemeEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/ThemeEffect.kt
@@ -1,79 +1,129 @@
 package com.example.abys.ui.effects
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.IntRange
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Stable
 import com.example.abys.R
+import kotlin.ranges.IntRange as KotlinIntRange
 
+/** Типы эффектов, которые умеет рендерить EffectLayer */
 enum class EffectKind { LEAVES, RAIN, SNOW, LIGHTNING, WIND, STORM, SUNSET_SNOW, NIGHT }
 
-sealed interface EffectParams {
-    val kind: EffectKind
-}
+/** Базовый «контракт» параметров эффекта */
+@Stable
+sealed interface EffectParams { val kind: EffectKind }
+
+/* ----------------------------- ПАРАМЕТРЫ ЭФФЕКТОВ ----------------------------- */
 
 data class LeavesParams(
-    val density: Float,
-    val speedY: Float,
-    val driftX: Float
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.LEAVES
-}
+    /** относительная плотность (частиц/площадь), 0.05..0.25 */
+    val density: Float = 0.12f,
+    /** вертикальная скорость базовая */
+    val speedY: Float = 0.9f,
+    /** амплитуда горизонтального дрейфа */
+    val driftX: Float = 0.45f
+) : EffectParams { override val kind = EffectKind.LEAVES }
 
 data class RainParams(
-    val dropsCount: Int,
-    val speed: Float,
-    val angleDeg: Float
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.RAIN
-}
+    /** целевое количество капель на эталонной площади (1080x1920) */
+    val dropsCount: Int = 140,
+    /** базовая скорость падения (пикс/кадр нормированно) */
+    val speed: Float = 14f,
+    /** угол наклона струек в градусах */
+    val angleDeg: Float = 18f
+) : EffectParams { override val kind = EffectKind.RAIN }
 
 data class SnowParams(
-    val flakesCount: Int,
-    val speed: Float,
-    val driftX: Float,
-    val size: ClosedFloatingPointRange<Float>
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.SNOW
-}
+    /** целевое количество хлопьев на эталонной площади */
+    val flakesCount: Int = 100,
+    /** базовая скорость падения */
+    val speed: Float = 1.4f,
+    /** амплитуда дрейфа по X */
+    val driftX: Float = 0.4f,
+    /** диапазон радиусов (px) */
+    val size: ClosedFloatingPointRange<Float> = 1.5f..3.5f
+) : EffectParams { override val kind = EffectKind.SNOW }
 
 data class LightningParams(
-    val minDelayMs: Int,
-    val maxDelayMs: Int,
-    val flashAlpha: Float,
-    val flashMs: Int
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.LIGHTNING
-}
+    /** min задержка между вспышками (мс) */
+    val minDelayMs: Int = 1500,
+    /** max задержка между вспышками (мс) */
+    val maxDelayMs: Int = 6000,
+    /** прозрачность вспышки 0..1 */
+    val flashAlpha: Float = 0.85f,
+    /** длительность основной вспышки (мс), дальше — хвост */
+    val flashMs: Int = 80
+) : EffectParams { override val kind = EffectKind.LIGHTNING }
 
+/** Параметры ветра используются рендерером и модификаторами (см. Wind.kt) */
+data class WindParams(
+    val speed: Float = 0.06f,
+    val swayX: Float = 10f,
+    val swayY: Float = 4f,
+    val rotZDeg: Float = 0.45f,
+    val parallaxBack: Float = 0.25f,
+    val parallaxFront: Float = 0.10f,
+    val gustBoost: Float = 1.8f,
+    val gustPeriodSec: ClosedFloatingPointRange<Float> = 3f..7f
+) : EffectParams { override val kind = EffectKind.WIND }
+
+/** Ночное небо: звезды + мерцание */
+data class StarsParams(
+    val starsCount: Int = 70,
+    /** период мерцания одной звезды (мс), выбирается случайно в этом диапазоне */
+    val twinklePeriodMs: KotlinIntRange = 1400..2500
+) : EffectParams { override val kind = EffectKind.NIGHT }
+
+/**
+ * Композит «шторм»: дождь + ветер + молнии.
+ * [rain] управляет плотностью/углом капель, [wind] — свингом фона/карточки, [lightning] — огибающей вспышек.
+ */
 data class StormParams(
-    val rain: RainParams,
-    val wind: WindParams,
-    val lightning: LightningParams
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.STORM
-}
+    val rain: RainParams = RainParams(dropsCount = 160, speed = 16f, angleDeg = 20f),
+    val wind: WindParams = WindParams(
+        speed = 0.07f, swayX = 14f, swayY = 6f, rotZDeg = 0.65f,
+        parallaxBack = 0.30f, parallaxFront = 0.15f, gustBoost = 2.2f, gustPeriodSec = 3f..6.5f
+    ),
+    val lightning: LightningParams = LightningParams(minDelayMs = 2200, maxDelayMs = 5200, flashAlpha = 0.8f, flashMs = 70)
+) : EffectParams { override val kind = EffectKind.STORM }
+
+/* --------------------------------- ТЕМА --------------------------------- */
 
 data class ThemeSpec(
     val id: String,
     @StringRes val titleRes: Int,
     @DrawableRes val thumbRes: Int,
-    @DrawableRes val backgrounds: List<Int>,
+    /** Пак фонов для слайдера. IntArray — чтобы @DrawableRes работал на всём массиве. */
+    @DrawableRes val backgrounds: IntArray,
     val params: EffectParams,
-    val defaultIntensity: Int,
-    val supportsWindSway: Boolean,
-    val supportsFlash: Boolean
-)
+    /** 0..100 */
+    @IntRange(from = 0, to = 100) val defaultIntensity: Int = 60,
+    /** Хард-флаг (ручной оверрайд), если нужно принудительно включить кач карточки */
+    val supportsWindSway: Boolean = false,
+    /** Хард-флаг для визуальных «вспышек» поверх */
+    val supportsFlash: Boolean = false
+) {
+    /** Нормализованная интенсивность 0f..1f */
+    val intensityF: Float get() = (defaultIntensity.coerceIn(0, 100)) / 100f
+
+    /** Эффективные флаги, учитывающие тип params (шторм/ветер/молния) */
+    val supportsWindSwayEffective: Boolean
+        get() = supportsWindSway || params is StormParams || params.kind == EffectKind.WIND
+
+    val supportsFlashEffective: Boolean
+        get() = supportsFlash || params is StormParams || params.kind == EffectKind.LIGHTNING
+}
+
+/* ------------------------------- РЕЕСТР ТЕМ ------------------------------- */
 
 val THEMES: List<ThemeSpec> = listOf(
     ThemeSpec(
         id = "leaves",
         titleRes = R.string.theme_leaves,
         thumbRes = R.drawable.thumb_leaves,
-        backgrounds = listOf(R.drawable.theme_leaves_bg01),
-        params = LeavesParams(
-            density = 0.12f,
-            speedY = 0.9f,
-            driftX = 0.45f
-        ),
+        backgrounds = intArrayOf(R.drawable.theme_leaves_bg01),
+        params = LeavesParams(density = 0.12f, speedY = 0.9f, driftX = 0.45f),
         defaultIntensity = 65,
         supportsWindSway = false,
         supportsFlash = false
@@ -82,84 +132,45 @@ val THEMES: List<ThemeSpec> = listOf(
         id = "rain",
         titleRes = R.string.theme_rain,
         thumbRes = R.drawable.thumb_rain,
-        backgrounds = listOf(R.drawable.theme_rain_bg01),
-        params = RainParams(
-            dropsCount = 140,
-            speed = 14f,
-            angleDeg = 18f
-        ),
-        defaultIntensity = 70,
-        supportsWindSway = false,
-        supportsFlash = false
+        backgrounds = intArrayOf(R.drawable.theme_rain_bg01),
+        params = RainParams(dropsCount = 140, speed = 14f, angleDeg = 18f),
+        defaultIntensity = 70
     ),
     ThemeSpec(
         id = "snow",
         titleRes = R.string.theme_snow,
         thumbRes = R.drawable.thumb_snow,
-        backgrounds = listOf(R.drawable.theme_snow_bg01),
-        params = SnowParams(
-            flakesCount = 100,
-            speed = 1.4f,
-            driftX = 0.4f,
-            size = 1.5f..3.5f
-        ),
-        defaultIntensity = 55,
-        supportsWindSway = false,
-        supportsFlash = false
+        backgrounds = intArrayOf(R.drawable.theme_snow_bg01),
+        params = SnowParams(flakesCount = 100, speed = 1.4f, driftX = 0.4f, size = 1.5f..3.5f),
+        defaultIntensity = 55
     ),
     ThemeSpec(
         id = "lightning",
         titleRes = R.string.theme_lightning,
         thumbRes = R.drawable.thumb_lightning,
-        backgrounds = listOf(R.drawable.theme_lightning_bg01),
-        params = LightningParams(
-            minDelayMs = 1500,
-            maxDelayMs = 6000,
-            flashAlpha = 0.85f,
-            flashMs = 80
-        ),
+        backgrounds = intArrayOf(R.drawable.theme_lightning_bg01),
+        params = LightningParams(minDelayMs = 1500, maxDelayMs = 6000, flashAlpha = 0.85f, flashMs = 80),
         defaultIntensity = 40,
-        supportsWindSway = false,
         supportsFlash = true
     ),
     ThemeSpec(
         id = "wind",
         titleRes = R.string.theme_wind,
         thumbRes = R.drawable.thumb_wind,
-        backgrounds = listOf(R.drawable.theme_wind_bg01),
+        backgrounds = intArrayOf(R.drawable.theme_wind_bg01),
         params = WindParams(
-            speed = 0.065f,
-            swayX = 12f,
-            swayY = 5f,
-            rotZDeg = 0.5f,
-            parallaxBack = 0.25f,
-            parallaxFront = 0.12f,
-            gustBoost = 2.0f,
-            gustPeriodSec = 3.5f..7.5f
+            speed = 0.065f, swayX = 12f, swayY = 5f, rotZDeg = 0.5f,
+            parallaxBack = 0.25f, parallaxFront = 0.12f, gustBoost = 2.0f, gustPeriodSec = 3.5f..7.5f
         ),
         defaultIntensity = 60,
-        supportsWindSway = true,
-        supportsFlash = false
+        supportsWindSway = true
     ),
     ThemeSpec(
         id = "storm",
         titleRes = R.string.theme_storm,
         thumbRes = R.drawable.thumb_storm,
-        backgrounds = listOf(R.drawable.theme_storm_bg01),
-        params = StormParams(
-            rain = RainParams(dropsCount = 160, speed = 16f, angleDeg = 20f),
-            wind = WindParams(
-                speed = 0.07f,
-                swayX = 14f,
-                swayY = 6f,
-                rotZDeg = 0.65f,
-                parallaxBack = 0.3f,
-                parallaxFront = 0.15f,
-                gustBoost = 2.2f,
-                gustPeriodSec = 3f..6.5f
-            ),
-            lightning = LightningParams(minDelayMs = 2200, maxDelayMs = 5200, flashAlpha = 0.8f, flashMs = 70)
-        ),
+        backgrounds = intArrayOf(R.drawable.theme_storm_bg01),
+        params = StormParams(), // см. дефолты выше
         defaultIntensity = 75,
         supportsWindSway = true,
         supportsFlash = true
@@ -168,27 +179,21 @@ val THEMES: List<ThemeSpec> = listOf(
         id = "sunset_snow",
         titleRes = R.string.theme_sunset_snow,
         thumbRes = R.drawable.thumb_sunset_snow,
-        backgrounds = listOf(R.drawable.theme_sunset_snow_bg01),
-        params = SnowParams(
-            flakesCount = 80,
-            speed = 0.9f,
-            driftX = 0.3f,
-            size = 2.0f..4.5f
-        ),
-        defaultIntensity = 50,
-        supportsWindSway = false,
-        supportsFlash = false
+        backgrounds = intArrayOf(R.drawable.theme_sunset_snow_bg01),
+        params = SnowParams(flakesCount = 80, speed = 0.9f, driftX = 0.3f, size = 2.0f..4.5f),
+        defaultIntensity = 50
     ),
     ThemeSpec(
         id = "night",
         titleRes = R.string.theme_night,
         thumbRes = R.drawable.thumb_night,
-        backgrounds = listOf(R.drawable.theme_night_bg01),
+        backgrounds = intArrayOf(R.drawable.theme_night_bg01),
         params = StarsParams(starsCount = 70, twinklePeriodMs = 1400..2500),
-        defaultIntensity = 45,
-        supportsWindSway = false,
-        supportsFlash = false
+        defaultIntensity = 45
     )
 )
 
-fun themeById(id: String): ThemeSpec = THEMES.firstOrNull { it.id == id } ?: THEMES.first()
+private val THEMES_BY_ID: Map<String, ThemeSpec> = THEMES.associateBy { it.id }
+
+/** Безопасный доступ по id с фолбэком на первую тему */
+fun themeById(id: String): ThemeSpec = THEMES_BY_ID[id] ?: THEMES.first()

--- a/app/src/main/java/com/example/abys/ui/effects/Wind.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/Wind.kt
@@ -15,19 +15,6 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
 
-data class WindParams(
-    val speed: Float = 0.06f,                  // базовая угловая скорость фазы
-    val swayX: Float = 10f,                    // амплитуда сдвига X для карточки
-    val swayY: Float = 4f,                     // амплитуда сдвига Y для карточки
-    val rotZDeg: Float = 0.45f,                // лёгкий наклон карточки при ветре (в градусах)
-    val parallaxBack: Float = 0.25f,           // коэффициент параллакса для задних слоёв (фон)
-    val parallaxFront: Float = 0.10f,          // коэффициент параллакса для передних слоёв (например, снежинки)
-    val gustBoost: Float = 1.8f,               // насколько усиливается ветер при порыве
-    val gustPeriodSec: ClosedFloatingPointRange<Float> = 3f..7f  // длительность порыва
-): EffectParams {
-    override val kind: EffectKind = EffectKind.WIND
-}
-
 /** Текущее состояние ветра — читается UI-слоями. */
 @Stable
 data class WindState(


### PR DESCRIPTION
## Summary
- add StarsParams and expand effect parameter data classes with documented defaults
- tighten ThemeSpec API with intensity helpers, @IntRange annotations, and array-backed backgrounds
- provide a THEMES_BY_ID lookup map and reuse the shared WindParams definition

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: no JDK 17 configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68edaceef7b0832d86ad56598c5b902a