### PR TITLE
Expose shared wind state and refine effect layer transitions

### DIFF
--- a/app/src/main/java/com/example/abys/ui/effects/EffectLayer.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/EffectLayer.kt
@@ -1,7 +1,12 @@
 package com.example.abys.ui.effects
 
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 
 @Composable
@@ -10,19 +15,44 @@ fun EffectLayer(
     theme: ThemeSpec,
     intensityOverride: Float? = null
 ) {
-    Crossfade(targetState = theme, label = "effect-crossfade") { spec ->
-        val intensity = (intensityOverride ?: (spec.defaultIntensity / 100f)).coerceIn(0f, 1f)
+    val intensity = (intensityOverride ?: (theme.defaultIntensity / 100f)).coerceIn(0f, 1f)
+    if (intensity <= 0f) return
 
-        when (val params = spec.params) {
-            is LeavesParams -> LeavesEffect(modifier, params, intensity)
-            is RainParams -> RainEffect(modifier, params, intensity)
-            is SnowParams -> SnowEffect(modifier, params, intensity)
-            is LightningParams -> LightningOverlay(modifier, params, intensity)
-            is WindParams -> Unit
-            is StarsParams -> StarsEffect(modifier, params, intensity)
-            is StormParams -> {
-                RainEffect(modifier, params.rain, intensity)
-                LightningOverlay(modifier, params.lightning, intensity)
+    AnimatedContent(
+        targetState = theme.params.kind,
+        transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(140)) },
+        label = "effect-kind"
+    ) { kind ->
+        key(kind) {
+            when (kind) {
+                EffectKind.LEAVES -> {
+                    val p = theme.params as LeavesParams
+                    LeavesEffect(modifier, p, intensity)
+                }
+                EffectKind.RAIN -> {
+                    val p = theme.params as RainParams
+                    RainEffect(modifier, p, intensity)
+                }
+                EffectKind.SNOW, EffectKind.SUNSET_SNOW -> {
+                    val p = theme.params as SnowParams
+                    SnowEffect(modifier, p, intensity)
+                }
+                EffectKind.LIGHTNING -> {
+                    val p = theme.params as LightningParams
+                    LightningOverlay(modifier, p, intensity)
+                }
+                EffectKind.WIND -> {
+                    // ветер применяется к UI через LocalWind
+                }
+                EffectKind.NIGHT -> {
+                    val p = theme.params as StarsParams
+                    StarsEffect(modifier, p, intensity)
+                }
+                EffectKind.STORM -> {
+                    val p = theme.params as StormParams
+                    RainEffect(modifier, p.rain, intensity)
+                    LightningOverlay(modifier, p.lightning, intensity)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- expose a LocalWind composition local and ProvideWind helper to share wind state across UI
- refactor EffectLayer to use AnimatedContent keyed by effect type and skip work when intensity is zero
- update HomeScreen to consume the shared wind state for parallax and sway instead of recomputing it locally

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing configured JDK in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edaf7ffa58832d8b1f3b773369d83b