### PR TITLE
Refine prayer time repository and location helper

### DIFF
--- a/app/src/main/java/com/example/abys/data/model/PrayerTimes.kt
+++ b/app/src/main/java/com/example/abys/data/model/PrayerTimes.kt
@@ -1,7 +1,6 @@
 package com.example.abys.data.model
 
-import com.example.abys.util.TimeUtils          // ← правильный импорт
-import com.squareup.moshi.Json
+import com.example.abys.util.TimeUtils
 
 data class PrayerTimes(
     val fajr: String,
@@ -10,16 +9,6 @@ data class PrayerTimes(
     val maghrib: String,
     val isha: String
 ) {
-    companion object {
-        /** конвертация из json-структуры AlAdhan */
-        fun fromApi(t: Timings): PrayerTimes = PrayerTimes(
-            fajr = t.fajr,
-            dhuhr = t.dhuhr,
-            asr = t.asr,
-            maghrib = t.maghrib,
-            isha = t.isha
-        )
-    }
 
     /** Возвращает название и время ближайшего намаза */
     fun next(nowSec: Int): Pair<String, String> =
@@ -29,18 +18,6 @@ data class PrayerTimes(
             "Asr" to asr,
             "Maghrib" to maghrib,
             "Isha" to isha
-        ).first { TimeUtils.hmsToSec(it.second) > nowSec }
+        ).firstOrNull { TimeUtils.hmsToSec(it.second) > nowSec }
+            ?: ("Fajr" to fajr)
 }
-
-/* ===== Retrofit DTO ===== */
-data class ApiResponse(val data: Data?) {
-    data class Data(val timings: Timings)
-}
-
-data class Timings(
-    @Json(name = "Fajr")    val fajr: String,
-    @Json(name = "Dhuhr")   val dhuhr: String,
-    @Json(name = "Asr")     val asr: String,
-    @Json(name = "Maghrib") val maghrib: String,
-    @Json(name = "Isha")    val isha: String
-)

--- a/app/src/main/java/com/example/abys/net/RetrofitProvider.kt
+++ b/app/src/main/java/com/example/abys/net/RetrofitProvider.kt
@@ -1,15 +1,31 @@
 package com.example.abys.net
 
+import com.example.abys.BuildConfig
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
 
 object RetrofitProvider {
 
-    /* ---------- общий OkHttpClient (без лог-интерсептора) ---------- */
-    private val okHttp: OkHttpClient = OkHttpClient.Builder()
-        .build()
+    /* ---------- общий OkHttpClient (с optional-логированием) ---------- */
+    private val okHttp: OkHttpClient by lazy {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .writeTimeout(20, TimeUnit.SECONDS)
+
+        if (BuildConfig.DEBUG) {
+            val logging = HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
+            builder.addInterceptor(logging)
+        }
+
+        builder.build()
+    }
 
     /* ---------- AlAdhan API ---------- */
     val aladhan: AladhanApi by lazy {

--- a/app/src/main/java/com/example/abys/util/LocationHelper.kt
+++ b/app/src/main/java/com/example/abys/util/LocationHelper.kt
@@ -6,8 +6,12 @@ import android.location.Location
 import android.location.LocationManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
 
 object LocationHelper {
+
+    private const val ACCEPTABLE_ACCURACY_METERS = 200f
+    private val MAX_LOCATION_AGE_MILLIS = TimeUnit.HOURS.toMillis(2)
 
     /** Возвращает (lat, lon) или null, если ничего не доступно. */
     @SuppressLint("MissingPermission")
@@ -24,10 +28,25 @@ object LocationHelper {
             LocationManager.GPS_PROVIDER,
             LocationManager.NETWORK_PROVIDER,
             LocationManager.PASSIVE_PROVIDER
-        ).filter { lm.isProviderEnabled(it) }
+        ).filter { provider ->
+            runCatching { lm.isProviderEnabled(provider) }.getOrDefault(false)
+        }
 
-        return providers
-            .mapNotNull { lm.getLastKnownLocation(it) }
-            .minByOrNull { it.accuracy }
+        if (providers.isEmpty()) return null
+
+        val now = System.currentTimeMillis()
+
+        val locations = providers
+            .mapNotNull { provider ->
+                runCatching { lm.getLastKnownLocation(provider) }.getOrNull()
+            }
+            .ifEmpty { return null }
+
+        val recentLocations = locations.filter { now - it.time <= MAX_LOCATION_AGE_MILLIS }
+        val accurateRecent = recentLocations.filter { !it.hasAccuracy() || it.accuracy <= ACCEPTABLE_ACCURACY_METERS }
+
+        return accurateRecent.maxByOrNull { it.time }
+            ?: recentLocations.maxByOrNull { it.time }
+            ?: locations.maxByOrNull { it.time }
     }
 }


### PR DESCRIPTION
## Summary
- reuse the shared Aladhan API contract via RetrofitProvider and map responses into the domain PrayerTimes model
- simplify the PrayerTimes data class to keep only domain logic while retaining next-prayer calculation safeguards
- add timeouts and optional logging to RetrofitProvider and pick fresher, accurate last known locations

## Testing
- ./gradlew test *(fails: Java 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68edb90d2244832d87df8307717d9a85