### PR TITLE
Add missing Compose dependencies for HomeScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.runtime:runtime-livedata")
+    implementation("androidx.compose.runtime:runtime-saveable")
+    implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
@@ -71,6 +73,8 @@ dependencies {
 
     // Image loading
     implementation("io.coil-kt:coil-compose:2.6.0")
+
+    implementation("com.google.accompanist:accompanist-permissions:0.36.0")
 
     // java.time на API 23
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")


### PR DESCRIPTION
## Summary
- add the compose runtime-saveable artifact to provide rememberSaveable
- include the foundation library for FlowRow and other layout helpers
- add accompanist permissions dependency for the ExperimentalPermissionsApi usage

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68edc5d048b0832dad55ea866d39cca4