### PR TITLE
Fix HomeScreen compose imports

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,12 +49,16 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.runtime:runtime-livedata")
+    implementation("androidx.compose.runtime:runtime-saveable")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-layout")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
     implementation("androidx.activity:activity-compose:1.9.2")
     implementation("com.google.android.material:material:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
@@ -71,6 +75,8 @@ dependencies {
 
     // Image loading
     implementation("io.coil-kt:coil-compose:2.6.0")
+
+    implementation("com.google.accompanist:accompanist-permissions:0.36.0")
 
     // java.time на API 23
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")

--- a/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
## Summary
- correct the HomeScreen rememberSaveable import to use the runtime saveable package
- add lifecycle-viewmodel-compose for the viewModel() helper and foundation-layout for FlowRow

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68edc5d048b0832dad55ea866d39cca4