### PR TITLE
Fix compile issues in prayer app

### DIFF
--- a/app/src/main/java/com/example/abys/BuildConfig.kt
+++ b/app/src/main/java/com/example/abys/BuildConfig.kt
@@ -1,0 +1,12 @@
+package com.example.abys
+
+/**
+ * Minimal BuildConfig replacement used in tests.
+ * The Gradle plugin normally generates this, but the
+ * lightweight environment we run in does not. We only
+ * need the DEBUG flag for conditional logging.
+ */
+object BuildConfig {
+    const val DEBUG: Boolean = true
+}
+

--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -100,13 +100,13 @@ class MainViewModel(
             val tz = ZoneId.of(dStd.meta.timezone)
 
             val ui = UiTimings(
-                fajr    = dStd.timings.Fajr,
-                sunrise = dStd.timings.Sunrise,
-                dhuhr   = dStd.timings.Dhuhr,
-                asrStd  = dStd.timings.Asr,
-                asrHan  = dHan.timings.Asr,
-                maghrib = dStd.timings.Maghrib,
-                isha    = dStd.timings.Isha,
+                fajr    = dStd.timings.fajr,
+                sunrise = dStd.timings.sunrise,
+                dhuhr   = dStd.timings.dhuhr,
+                asrStd  = dStd.timings.asr,
+                asrHan  = dHan.timings.asr,
+                maghrib = dStd.timings.maghrib,
+                isha    = dStd.timings.isha,
                 tz      = tz
             )
             _timings.postValue(ui)

--- a/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
+++ b/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -95,6 +97,10 @@ fun SlideshowBackground(
         }
     }
 
+    val grayscaleFilter = remember {
+        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
+    }
+
     Box(modifier.fillMaxSize()) {
         // Рисуем до трёх слоёв для аккуратного кросс-фейда
         val imageModifier = Modifier
@@ -106,9 +112,9 @@ fun SlideshowBackground(
                 painter = painterResource(id = slides[prevIdx]),
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
-                    saturation = 0f
                     alpha = alphaPrev
                 },
+                colorFilter = grayscaleFilter,
                 contentScale = ContentScale.Crop
             )
         }
@@ -116,9 +122,9 @@ fun SlideshowBackground(
             painter = painterResource(id = slides[currIdx]),
             contentDescription = null,
             modifier = imageModifier.graphicsLayer {
-                saturation = 0f
                 alpha = alphaCurr
             },
+            colorFilter = grayscaleFilter,
             contentScale = ContentScale.Crop
         )
         if (alphaNext > 0f) {
@@ -126,9 +132,9 @@ fun SlideshowBackground(
                 painter = painterResource(id = slides[nextIdx]),
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
-                    saturation = 0f
                     alpha = alphaNext
                 },
+                colorFilter = grayscaleFilter,
                 contentScale = ContentScale.Crop
             )
         }

--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -52,6 +53,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -337,8 +339,8 @@ fun EffectCarousel(
                             val layoutInfo = state.layoutInfo
                             val center = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
                             if (center <= 0f) return@collectLatest
-                            val layoutInfo = state.layoutInfo
-                            val visible = layoutInfo.visibleItemsInfo
+                            val currentLayoutInfo = state.layoutInfo
+                            val visible = currentLayoutInfo.visibleItemsInfo
                             val closest = visible.minByOrNull { info ->
                                 val itemCenterPx = info.offset + info.size / 2f
                                 abs(itemCenterPx - center)

--- a/app/src/main/java/com/example/abys/ui/effects/RainEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/RainEffect.kt
@@ -16,13 +16,6 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
 
-/** Параметры дождя (оставь твой, если уже есть с такими полями) */
-data class RainParams(
-    val dropsCount: Int = 140,     // «бюджет» при intensity=1 и FullHD
-    val speed: Float = 12f,        // базовая скорость падения (px/кадр при 60 fps)
-    val angleDeg: Float = 15f      // наклон ветра (градусы от вертикали, вправо)
-)
-
 /** Внутренняя предсозданная «частица». Без аллокаций на кадр. */
 private class Drop(
     var x: Float,

--- a/app/src/main/java/com/example/abys/ui/effects/SeasonalParticles.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/SeasonalParticles.kt
@@ -1,0 +1,35 @@
+package com.example.abys.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import java.time.LocalDate
+import java.time.Month
+
+/**
+ * Simple helper that picks a particle theme based on the current month.
+ * It keeps the existing effect system so MainActivity can show something
+ * even when no explicit theme selection was made yet.
+ */
+@Composable
+fun SeasonalParticles(
+    modifier: Modifier = Modifier,
+    month: Month = LocalDate.now().month,
+    intensityOverride: Float? = null
+) {
+    val theme = remember(month) { month.toThemeSpec() }
+    EffectLayer(
+        modifier = modifier,
+        theme = theme,
+        intensityOverride = intensityOverride
+    )
+}
+
+private fun Month.toThemeSpec(): ThemeSpec = when (this) {
+    Month.DECEMBER, Month.JANUARY, Month.FEBRUARY -> themeById("snow")
+    Month.MARCH, Month.APRIL -> themeById("rain")
+    Month.MAY, Month.JUNE, Month.JULY, Month.AUGUST -> themeById("storm")
+    Month.SEPTEMBER, Month.OCTOBER -> themeById("leaves")
+    Month.NOVEMBER -> themeById("night")
+}
+

--- a/app/src/main/java/com/example/abys/ui/effects/SnowEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/SnowEffect.kt
@@ -144,7 +144,8 @@ fun SnowEffect(
     Canvas(
         modifier = modifier.onSizeChanged { size = it }
     ) {
-        val _ = frame
+        val frameTick = frame
+        if (frameTick < 0) return@Canvas
         for (index in 0 until flakesCount) {
             drawCircle(
                 color = Color.White,

--- a/app/src/main/java/com/example/abys/ui/effects/StarsEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/StarsEffect.kt
@@ -21,20 +21,6 @@ import kotlin.math.max
 import kotlin.math.sin
 import kotlin.random.Random
 
-data class StarsParams(
-    val starsCount: Int = 64,
-    val twinklePeriodMs: IntRange = 1200..2400,
-    val twinkleAmplitude: Float = 0.65f,
-    val baseAlpha: ClosedFloatingPointRange<Float> = 0.35f..0.85f,
-    val shootingStars: Int = 2,
-    val shootingIntervalMs: IntRange = 20000..35000,
-    val shootingSpeedPxSec: Float = 900f,
-    val tailLengthPx: Float = 160f,
-    val tailAlpha: Float = 0.9f
-) : EffectParams {
-    override val kind: EffectKind = EffectKind.NIGHT
-}
-
 /**
  * Звёздное небо:
  * - 3 слоя звёзд (размер/альфа/скорость мерцания отличаются) → ощущение глубины
@@ -220,7 +206,8 @@ fun StarsEffect(
     }
 
     Canvas(modifier = modifier.onSizeChanged { size = it }) {
-        val _ = frame
+        val frameTick = frame
+        if (frameTick < 0) return@Canvas
 
         for (i in 0 until n) {
             drawCircle(

--- a/app/src/main/java/com/example/abys/ui/effects/ThemeEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/ThemeEffect.kt
@@ -72,7 +72,14 @@ data class WindParams(
 data class StarsParams(
     val starsCount: Int = 70,
     /** период мерцания одной звезды (мс), выбирается случайно в этом диапазоне */
-    val twinklePeriodMs: KotlinIntRange = 1400..2500
+    val twinklePeriodMs: KotlinIntRange = 1400..2500,
+    val twinkleAmplitude: Float = 0.65f,
+    val baseAlpha: ClosedFloatingPointRange<Float> = 0.35f..0.85f,
+    val shootingStars: Int = 2,
+    val shootingIntervalMs: KotlinIntRange = 20000..35000,
+    val shootingSpeedPxSec: Float = 900f,
+    val tailLengthPx: Float = 160f,
+    val tailAlpha: Float = 0.9f
 ) : EffectParams { override val kind = EffectKind.NIGHT }
 
 /**


### PR DESCRIPTION
## Summary
- align MainViewModel to use the generated timing field names
- add a lightweight BuildConfig, seasonal particle helper, and consolidate effect params
- replace the deprecated saturation layer with a reusable grayscale color filter

## Testing
- :app:compileDebugKotlin *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edcfedc308832d88f6206e36b010ef