### PR TITLE
Fix EffectCarousel semantics string resource usage

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -193,6 +193,18 @@ fun EffectCarousel(
                             }
                         }
                         val title = stringResource(id = spec.titleRes)
+                        val talkbackDescription = stringResource(
+                            id = R.string.theme_apply_talkback,
+                            title
+                        )
+                        val applyActionLabel = stringResource(
+                            id = R.string.theme_apply_action,
+                            title
+                        )
+                        val doubleTapLabel = stringResource(
+                            id = R.string.theme_apply_double_tap,
+                            title
+                        )
 
                         Box(
                             Modifier
@@ -246,18 +258,15 @@ fun EffectCarousel(
                                     )
                                 }
                                 .semantics(mergeDescendants = true) {
-                                    contentDescription = stringResource(
-                                        id = R.string.theme_apply_talkback,
-                                        title
-                                    )
-                                    onClick(label = stringResource(id = R.string.theme_apply_action, title)) {
+                                    contentDescription = talkbackDescription
+                                    onClick(label = applyActionLabel) {
                                         if (!isCentered) return@onClick false
                                         applyAndCollapse(spec, updatedOnTapApply)
                                         true
                                     }
                                     customActions = listOf(
                                         CustomAccessibilityAction(
-                                            label = stringResource(id = R.string.theme_apply_double_tap, title)
+                                            label = doubleTapLabel
                                         ) {
                                             if (state.isScrollInProgress) return@CustomAccessibilityAction false
                                             scope.launch {


### PR DESCRIPTION
## Summary
- precompute accessibility strings for EffectCarousel items
- avoid calling stringResource from non-composable semantics lambdas

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edd34c6a24832dacf16fa79f9e0a65