### PR TITLE
Refine home experience and offline resilience

### DIFF
--- a/app/src/main/java/com/example/abys/data/PrayerTimesSerializer.kt
+++ b/app/src/main/java/com/example/abys/data/PrayerTimesSerializer.kt
@@ -1,0 +1,89 @@
+package com.example.abys.data
+
+import com.example.abys.data.model.PrayerTimes
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.time.ZoneId
+
+private data class PrayerTimesSnapshot(
+    val fajr: String,
+    val sunrise: String,
+    val dhuhr: String,
+    val asrStandard: String,
+    val asrHanafi: String,
+    val maghrib: String,
+    val isha: String,
+    val imsak: String?,
+    val sunset: String?,
+    val midnight: String?,
+    val firstThird: String?,
+    val lastThird: String?,
+    val timezone: String,
+    val methodName: String?,
+    val readableDate: String?,
+    val hijriDate: String?,
+    val hijriMonth: String?,
+    val hijriYear: String?
+)
+
+object PrayerTimesSerializer {
+    private val moshi: Moshi by lazy {
+        Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    private val adapter = moshi.adapter(PrayerTimesSnapshot::class.java)
+
+    fun encode(value: PrayerTimes): String? {
+        val snapshot = value.toSnapshot()
+        return runCatching { adapter.toJson(snapshot) }.getOrNull()
+    }
+
+    fun decode(json: String): PrayerTimes? {
+        val snapshot = runCatching { adapter.fromJson(json) }.getOrNull() ?: return null
+        return snapshot.toModel()
+    }
+}
+
+private fun PrayerTimes.toSnapshot(): PrayerTimesSnapshot = PrayerTimesSnapshot(
+    fajr = fajr,
+    sunrise = sunrise,
+    dhuhr = dhuhr,
+    asrStandard = asrStandard,
+    asrHanafi = asrHanafi,
+    maghrib = maghrib,
+    isha = isha,
+    imsak = imsak,
+    sunset = sunset,
+    midnight = midnight,
+    firstThird = firstThird,
+    lastThird = lastThird,
+    timezone = timezone.id,
+    methodName = methodName,
+    readableDate = readableDate,
+    hijriDate = hijriDate,
+    hijriMonth = hijriMonth,
+    hijriYear = hijriYear
+)
+
+private fun PrayerTimesSnapshot.toModel(): PrayerTimes = PrayerTimes(
+    fajr = fajr,
+    sunrise = sunrise,
+    dhuhr = dhuhr,
+    asrStandard = asrStandard,
+    asrHanafi = asrHanafi,
+    maghrib = maghrib,
+    isha = isha,
+    imsak = imsak,
+    sunset = sunset,
+    midnight = midnight,
+    firstThird = firstThird,
+    lastThird = lastThird,
+    timezone = runCatching { ZoneId.of(timezone) }.getOrDefault(ZoneId.systemDefault()),
+    methodName = methodName,
+    readableDate = readableDate,
+    hijriDate = hijriDate,
+    hijriMonth = hijriMonth,
+    hijriYear = hijriYear
+)

--- a/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
+++ b/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
@@ -4,20 +4,25 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import kotlinx.coroutines.delay
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
 import kotlin.math.floor
+import kotlin.math.sin
 
 /**
  * Детерминированное слайд-шоу:
@@ -90,7 +95,21 @@ fun SlideshowBackground(
         }
     }
 
-    Box(modifier.fillMaxSize()) {
+    val driftPhase = (nowMs % 16000L) / 16000f
+    val driftX = sin(driftPhase * 2f * PI).toFloat() * 12f
+    val driftY = cos(driftPhase * 2f * PI).toFloat() * 8f
+    val baseScale = 1.04f
+
+    val progress = (within / period).toFloat().coerceIn(0f, 1f)
+    val topAlpha = 0.06f + 0.06f * progress
+    val bottomAlpha = 0.18f + 0.06f * (1f - kotlin.math.abs(progress - 0.5f) * 2f)
+
+    Box(
+        modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.1f)),
+        contentAlignment = Alignment.Center
+    ) {
         // Рисуем до трёх слоёв для аккуратного кросс-фейда
         val imageModifier = Modifier
             .fillMaxSize()
@@ -101,8 +120,12 @@ fun SlideshowBackground(
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
                     alpha = alphaPrev
+                    scaleX = baseScale
+                    scaleY = baseScale
+                    translationX = driftX
+                    translationY = driftY
                 },
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Fit
             )
         }
         Image(
@@ -110,8 +133,12 @@ fun SlideshowBackground(
             contentDescription = null,
             modifier = imageModifier.graphicsLayer {
                 alpha = alphaCurr
+                scaleX = baseScale
+                scaleY = baseScale
+                translationX = driftX
+                translationY = driftY
             },
-            contentScale = ContentScale.Crop
+            contentScale = ContentScale.Fit
         )
         if (alphaNext > 0f) {
             Image(
@@ -119,8 +146,12 @@ fun SlideshowBackground(
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
                     alpha = alphaNext
+                    scaleX = baseScale
+                    scaleY = baseScale
+                    translationX = driftX
+                    translationY = driftY
                 },
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Fit
             )
         }
 
@@ -131,8 +162,9 @@ fun SlideshowBackground(
                 .background(
                     Brush.verticalGradient(
                         listOf(
-                            Color.Black.copy(alpha = 0.15f),
-                            Color.Black.copy(alpha = 0.45f)
+                            Color.Black.copy(alpha = topAlpha),
+                            Color.Transparent,
+                            Color.Black.copy(alpha = bottomAlpha)
                         )
                     )
                 )

--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -2,7 +2,6 @@ package com.example.abys.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -10,12 +9,15 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -38,7 +40,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -81,8 +82,7 @@ fun EffectCarousel(
     val scope = rememberCoroutineScope()
     val haptics = LocalHapticFeedback.current
 
-    val alpha by animateFloatAsState(targetValue = if (collapsed) 0.35f else 1f, label = "carAlpha")
-    val targetHeight = if (collapsed) 72.dp else 132.dp
+    val targetHeight = if (collapsed) 96.dp else 156.dp
     val height by animateDpAsState(targetValue = targetHeight, label = "carHeight")
     val updatedOnSnapped by rememberUpdatedState(onThemeSnapped)
     val updatedOnDoubleTap by rememberUpdatedState(onDoubleTapApply)
@@ -96,34 +96,74 @@ fun EffectCarousel(
         Modifier
             .fillMaxWidth()
             .height(height)
-            .alpha(alpha)
-            .pointerInput(collapsed) {
-                detectTapGestures(onTap = { if (collapsed) onCollapsedChange(false) })
-            }
     ) {
         if (collapsed) {
             val selectedTheme = remember(selectedThemeId, themes) {
                 themes.firstOrNull { it.id == selectedThemeId } ?: themes.first()
             }
-            Box(
-                Modifier
+            Surface(
+                modifier = Modifier
                     .align(Alignment.Center)
-                    .size(68.dp)
-                    .clip(RoundedCornerShape(20.dp))
-                    .border(
-                        width = 2.dp,
-                        brush = Brush.verticalGradient(
-                            listOf(Color.White.copy(alpha = 0.35f), Color.White.copy(alpha = 0.12f))
-                        ),
-                        shape = RoundedCornerShape(20.dp)
-                    )
-                    .background(Color.Black.copy(alpha = 0.35f))
+                    .padding(horizontal = 32.dp)
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = stringResource(id = R.string.theme_carousel_expand)
+                    },
+                shape = RoundedCornerShape(28.dp),
+                color = Color.Black.copy(alpha = 0.58f),
+                tonalElevation = 2.dp,
+                onClick = { onCollapsedChange(false) }
             ) {
-                Image(
-                    painter = painterResource(id = selectedTheme.thumbRes),
-                    contentDescription = stringResource(id = selectedTheme.titleRes),
-                    modifier = Modifier.fillMaxSize()
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 18.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            Modifier
+                                .size(48.dp)
+                                .clip(RoundedCornerShape(16.dp))
+                                .border(
+                                    width = 2.dp,
+                                    brush = Brush.verticalGradient(
+                                        listOf(Color.White.copy(alpha = 0.38f), Color.White.copy(alpha = 0.14f))
+                                    ),
+                                    shape = RoundedCornerShape(16.dp)
+                                )
+                                .background(Color.Black.copy(alpha = 0.35f))
+                        ) {
+                            Image(
+                                painter = painterResource(id = selectedTheme.thumbRes),
+                                contentDescription = null,
+                                modifier = Modifier.fillMaxSize()
+                            )
+                        }
+                        Spacer(Modifier.width(14.dp))
+                        Column {
+                            Text(
+                                text = stringResource(id = R.string.theme_carousel_handle),
+                                style = MaterialTheme.typography.titleMedium,
+                                color = Color.White,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = stringResource(id = selectedTheme.titleRes),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = Color.White.copy(alpha = 0.75f)
+                            )
+                        }
+                    }
+                    Text(
+                        text = "\u02C4",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = Color.White.copy(alpha = 0.9f)
+                    )
+                }
             }
         } else {
             var snappedIndex by remember { mutableStateOf(0) }
@@ -392,9 +432,43 @@ fun EffectCarousel(
                 }
             }
 
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 4.dp)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = stringResource(id = R.string.theme_carousel_collapse)
+                    },
+                shape = RoundedCornerShape(18.dp),
+                color = Color.Black.copy(alpha = 0.42f),
+                tonalElevation = 1.dp,
+                onClick = { onCollapsedChange(true) }
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.theme_carousel_handle),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = Color.White
+                    )
+                    Text(
+                        text = "\u02C5",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = Color.White.copy(alpha = 0.9f)
+                    )
+                }
+            }
+
             LaunchedEffect(collapsed) {
                 if (!collapsed) {
+                    showHint = true
                     delay(3200)
+                    showHint = false
+                } else {
                     showHint = false
                 }
             }

--- a/app/src/main/java/com/example/abys/ui/components/GlassCard.kt
+++ b/app/src/main/java/com/example/abys/ui/components/GlassCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -19,31 +20,32 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun GlassCard(
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(16.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 26.dp),
     content: @Composable () -> Unit
 ) {
     Box(modifier) {
         Box(
             Modifier
                 .matchParentSize()
-                .blur(36.dp)
+                .blur(22.dp)
                 .background(
                     Brush.verticalGradient(
                         listOf(
-                            Color.White.copy(alpha = 0.22f),
-                            Color.White.copy(alpha = 0.08f)
+                            Color.White.copy(alpha = 0.16f),
+                            Color.White.copy(alpha = 0.06f)
                         )
                     )
                 )
         )
         Card(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxWidth()
+                .wrapContentHeight(),
             colors = CardDefaults.cardColors(
-                containerColor = Color.White.copy(alpha = 0.18f)
+                containerColor = Color.White.copy(alpha = 0.16f)
             ),
-            shape = RoundedCornerShape(28.dp),
-            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.45f))
+            shape = RoundedCornerShape(26.dp),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.38f))
         ) {
             Box(Modifier.padding(contentPadding)) { content() }
         }

--- a/app/src/main/java/com/example/abys/ui/components/PrayerTable.kt
+++ b/app/src/main/java/com/example/abys/ui/components/PrayerTable.kt
@@ -2,22 +2,38 @@ package com.example.abys.ui.components
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.abys.R
 import com.example.abys.logic.TimeHelper
 import com.example.abys.logic.UiTimings
-import kotlinx.coroutines.delay
 import java.time.Duration
 import java.time.ZoneId
-import com.example.abys.R
+import kotlinx.coroutines.delay
 
 @Composable
 fun PrayerTable(t: UiTimings, selectedSchool: Int, highlightKey: String? = null) {
@@ -28,57 +44,93 @@ fun PrayerTable(t: UiTimings, selectedSchool: Int, highlightKey: String? = null)
     val next = t.nextPrayer(selectedSchool)
     val remain: Duration? = next?.second?.let { TimeHelper.untilNowTo(it, tz) }
 
+    val asrAltTime = if (selectedSchool == 1) t.asrStd else t.asrHan
+    val asrAltLabel = if (selectedSchool == 1) R.string.prayer_asr_alt_standard else R.string.prayer_asr_alt_hanafi
+
     val rows = listOf(
-        Triple("Fajr", R.string.prayer_fajr, t.fajr),
-        Triple("Shuruq", R.string.prayer_shuruq, t.sunrise),
-        Triple("Dhuhr", R.string.prayer_dhuhr, t.dhuhr),
-        Triple("Asr", R.string.prayer_asr, t.asr(selectedSchool)),
-        Triple("Maghrib", R.string.prayer_maghrib, t.maghrib),
-        Triple("Isha", R.string.prayer_isha, t.isha)
+        PrayerRow("Fajr", R.string.prayer_fajr, t.fajr),
+        PrayerRow("Shuruq", R.string.prayer_shuruq, t.sunrise),
+        PrayerRow("Dhuhr", R.string.prayer_dhuhr, t.dhuhr),
+        PrayerRow(
+            key = "Asr",
+            titleRes = R.string.prayer_asr,
+            time = t.asr(selectedSchool),
+            secondary = stringResource(id = asrAltLabel, asrAltTime)
+        ),
+        PrayerRow("Maghrib", R.string.prayer_maghrib, t.maghrib),
+        PrayerRow("Isha", R.string.prayer_isha, t.isha)
     )
 
-    Column(Modifier.fillMaxWidth()) {
-        rows.forEachIndexed { index, (key, label, time) ->
-            val active = highlightKey == key || next?.first == key
+    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        rows.forEach { row ->
+            val active = highlightKey == row.key || next?.first == row.key
             val background by animateColorAsState(
                 if (active) MaterialTheme.colorScheme.primary.copy(alpha = 0.14f) else Color.Transparent,
                 label = "prayerRowBg"
             )
-            Row(
-                Modifier
+
+            Surface(
+                modifier = Modifier
                     .fillMaxWidth()
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(background)
-                    .padding(horizontal = 14.dp, vertical = 10.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(background),
+                color = Color.Transparent
             ) {
-                Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 18.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Text(
-                        text = time,
-                        style = if (active) MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.primary)
-                        else MaterialTheme.typography.titleLarge
+                        text = stringResource(id = row.titleRes),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
                     )
-                    if (active && remain != null) {
-                        val h = remain.toHours()
-                        val m = remain.toMinutes() % 60
-                        val s = remain.seconds % 60
+
+                    Column(
+                        modifier = Modifier.sizeIn(minWidth = 96.dp),
+                        horizontalAlignment = Alignment.End
+                    ) {
                         Text(
-                            text = stringResource(id = R.string.prayer_remaining, h, m, s),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary
+                            text = row.time,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            textAlign = TextAlign.End,
+                            color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
                         )
+                        if (row.secondary != null) {
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = row.secondary,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.End
+                            )
+                        }
+                        if (active && remain != null) {
+                            Spacer(Modifier.height(4.dp))
+                            val h = remain.toHours()
+                            val m = remain.toMinutes() % 60
+                            val s = remain.seconds % 60
+                            Text(
+                                text = stringResource(id = R.string.prayer_remaining, h, m, s),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                textAlign = TextAlign.End
+                            )
+                        }
                     }
                 }
-                Text(
-                    text = stringResource(id = label),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-                )
-            }
-            if (index != rows.lastIndex) {
-                Spacer(Modifier.height(6.dp))
             }
         }
     }
 }
+
+private data class PrayerRow(
+    val key: String,
+    val titleRes: Int,
+    val time: String,
+    val secondary: String? = null
+)

--- a/app/src/main/java/com/example/abys/ui/effects/Wind.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/Wind.kt
@@ -129,11 +129,12 @@ fun rememberWind(
 /* ------------------------------ МОДИФИКАТОРЫ ------------------------------ */
 
 /** Применить ветер к «стеклянной» карточке (сдвиг + лёгкий наклон). */
-fun Modifier.windSway(wind: WindState): Modifier =
+fun Modifier.windSway(wind: WindState, boost: Float = 1f): Modifier =
     this.graphicsLayer {
-        translationX = wind.swayX
-        translationY = wind.swayY
-        rotationZ = wind.rotZ
+        val clamped = boost.coerceIn(0.5f, 2.2f)
+        translationX = wind.swayX * clamped
+        translationY = wind.swayY * clamped
+        rotationZ = wind.rotZ * clamped
     }
 
 /** Параллакс: depth < 0 для задних слоёв (фон), > 0 — для передних. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="prayer_maghrib">Maghrib</string>
     <string name="prayer_isha">Isha</string>
     <string name="prayer_remaining">через %1$02d:%2$02d:%3$02d</string>
+    <string name="prayer_asr_alt_standard">Стандарт: %1$s</string>
+    <string name="prayer_asr_alt_hanafi">Ханафи: %1$s</string>
 
     <!-- Экран Home -->
     <string name="location_current">Текущее местоположение</string>
@@ -54,6 +56,13 @@
     <string name="prayer_meta_method_unknown">Метод расчёта</string>
     <string name="prayer_meta_timezone">Часовой пояс: %1$s</string>
     <string name="prayer_schedule_today">Намазы на сегодня</string>
+    <string name="prayer_load_error_cached">Не удалось обновить расписание. Показаны сохранённые данные.</string>
+    <string name="prayer_load_error_generic">Не удалось загрузить расписание. Попробуйте позже.</string>
+    <string name="prayer_empty_title">Здесь пока пусто</string>
+    <string name="prayer_empty_body">Выберите город или определите геолокацию, чтобы увидеть времена намазов.</string>
+    <string name="theme_carousel_handle">Темы</string>
+    <string name="theme_carousel_expand">Открыть подбор тем</string>
+    <string name="theme_carousel_collapse">Свернуть подбор тем</string>
 
     <!-- Поиск города -->
     <string name="city_search_title">Выбор города</string>


### PR DESCRIPTION
## Summary
- cache the most recent prayer timetable and restored theme so the home screen can render instantly offline
- rebalance the home layout with a shorter glass card, localized empty state, and a more discoverable theme carousel
- tune visual layers (background drift, snow clusters, wind sway, leaf gusts) for richer theme feedback

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68ede1d56088832d977e206556e4c59c