### PR TITLE
Add missing layout imports for carousel and glass card

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow

--- a/app/src/main/java/com/example/abys/ui/components/GlassCard.kt
+++ b/app/src/main/java/com/example/abys/ui/components/GlassCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape


### PR DESCRIPTION
## Summary
- import Row from the Compose layout package for the effect carousel component
- add the fillMaxWidth import for the glass card wrapper to restore the extension reference

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain` *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68edec71e3a4832d9c1d28294a7ff9e0