### PR TITLE
Rename custom GlassCard to FrostedGlassCard to avoid conflicts

### DIFF
--- a/app/src/main/java/com/example/abys/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/MainActivity.kt
@@ -31,7 +31,7 @@ import com.example.abys.logic.SettingsStore
 import com.example.abys.logic.TimeHelper
 import com.example.abys.ui.background.SlideshowBackground
 import com.example.abys.ui.city.CityPickerSheet
-import com.example.abys.ui.components.GlassCard
+import com.example.abys.ui.components.FrostedGlassCard
 import com.example.abys.ui.components.NightTimeline
 import com.example.abys.ui.components.PrayerBoard
 import com.example.abys.ui.components.TopOverlay
@@ -145,7 +145,7 @@ class MainActivity : AppCompatActivity() {
                 if (t != null) {
                     PrayerBoard(t!!, selectedSchool = sel)
                 } else {
-                    GlassCard(
+                    FrostedGlassCard(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp)

--- a/app/src/main/java/com/example/abys/ui/components/FrostedGlassCard.kt
+++ b/app/src/main/java/com/example/abys/ui/components/FrostedGlassCard.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,12 +14,12 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun GlassCard(
+fun FrostedGlassCard(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 26.dp),
     content: @Composable () -> Unit

--- a/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
@@ -62,7 +62,7 @@ import com.example.abys.ui.PrayerViewModel
 import com.example.abys.ui.city.CityPickerSheet
 import com.example.abys.ui.components.DayProgress
 import com.example.abys.ui.components.EffectCarousel
-import com.example.abys.ui.components.GlassCard
+import com.example.abys.ui.components.FrostedGlassCard
 import com.example.abys.ui.components.InfoPill
 import com.example.abys.ui.components.NextPrayerChip
 import com.example.abys.ui.components.NightTimeline
@@ -219,7 +219,7 @@ fun HomeScreen(viewModel: PrayerViewModel) {
                     is StormParams -> 1.45f
                     else -> 1f
                 }
-                GlassCard(
+                FrostedGlassCard(
                     modifier = Modifier
                         .fillMaxWidth(0.9f)
                         .heightIn(max = 520.dp)


### PR DESCRIPTION
## Summary
- rename the app-specific GlassCard composable to FrostedGlassCard
- update all call sites to reference the new FrostedGlassCard component

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68edeee8000c832da6330ecdc006047b