### PR TITLE
Fix semantics resource usage and layout modifier

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/components/EffectCarousel.kt
@@ -102,6 +102,7 @@ fun EffectCarousel(
             val selectedTheme = remember(selectedThemeId, themes) {
                 themes.firstOrNull { it.id == selectedThemeId } ?: themes.first()
             }
+            val expandDescription = stringResource(id = R.string.theme_carousel_expand)
             Surface(
                 modifier = Modifier
                     .align(Alignment.Center)
@@ -110,7 +111,7 @@ fun EffectCarousel(
                     .height(64.dp)
                     .semantics {
                         role = Role.Button
-                        contentDescription = stringResource(id = R.string.theme_carousel_expand)
+                        contentDescription = expandDescription
                     },
                 shape = RoundedCornerShape(28.dp),
                 color = Color.Black.copy(alpha = 0.58f),
@@ -433,13 +434,14 @@ fun EffectCarousel(
                 }
             }
 
+            val collapseDescription = stringResource(id = R.string.theme_carousel_collapse)
             Surface(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 4.dp)
                     .semantics {
                         role = Role.Button
-                        contentDescription = stringResource(id = R.string.theme_carousel_collapse)
+                        contentDescription = collapseDescription
                     },
                 shape = RoundedCornerShape(18.dp),
                 color = Color.Black.copy(alpha = 0.42f),

--- a/app/src/main/java/com/example/abys/ui/components/FrostedGlassCard.kt
+++ b/app/src/main/java/com/example/abys/ui/components/FrostedGlassCard.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,7 +27,7 @@ fun FrostedGlassCard(
     Box(modifier) {
         Box(
             Modifier
-                .matchParentSize()
+                .fillMaxSize()
                 .blur(22.dp)
                 .background(
                     Brush.verticalGradient(


### PR DESCRIPTION
## Summary
- precompute the carousel accessibility descriptions before applying semantics
- replace the unavailable `matchParentSize` modifier with `fillMaxSize` in the frosted glass card

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edfcb44864832d9b440381729450c7