### PR TITLE
Replace deprecated APIs to address build warnings

### DIFF
--- a/app/src/main/java/com/example/abys/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/MainActivity.kt
@@ -40,6 +40,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.card.MaterialCardView
+import kotlinx.coroutines.launch
 import java.time.Duration
 
 class MainActivity : AppCompatActivity() {
@@ -197,7 +198,7 @@ class MainActivity : AppCompatActivity() {
         cv.setContent {
             MaterialTheme {
                 CityPickerSheet(onPick = { picked ->
-                    lifecycleScope.launchWhenStarted {
+                    lifecycleScope.launch {
                         SettingsStore.setCity(this@MainActivity, picked.title)
                         SettingsStore.setLastCoordinates(this@MainActivity, picked.latitude, picked.longitude)
                     }

--- a/app/src/main/java/com/example/abys/ui/city/CityPickerSheet.kt
+++ b/app/src/main/java/com/example/abys/ui/city/CityPickerSheet.kt
@@ -121,7 +121,7 @@ fun CityPickerSheet(
                                 lineHeight = 16.sp
                             )
                         }
-                        Divider()
+                        HorizontalDivider()
                     }
                 }
             }

--- a/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screens/HomeScreen.kt
@@ -15,9 +15,9 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedCard
@@ -461,7 +461,7 @@ private fun HomeContent(
                 )
             }
 
-            Divider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
 
             AsrSelector(
                 selected = state.selectedSchool,


### PR DESCRIPTION
## Summary
- replace the deprecated `launchWhenStarted` call in `MainActivity` with a standard lifecycle coroutine launch
- switch deprecated `Divider` usages in Compose screens to `HorizontalDivider`

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee2e16488c832da4c44a8cafa3b469