### PR TITLE
Fix manifest namespace and centralize placeholder strings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.abys"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/app/src/main/java/com/example/abys/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
@@ -92,13 +93,15 @@ class MainActivity : AppCompatActivity() {
 
         tvDate.text = TimeHelper.todayHuman()
 
-        vm.city.observe(this) { tvCity.text = it ?: "—" }
+        vm.city.observe(this) { tvCity.text = it ?: getString(R.string.placeholder_dash) }
 
         vm.timings.observe(this) { t ->
             val sel = vm.school.value ?: 0
             renderTimings(t?.toDisplayList(sel).orEmpty(), t?.nextPrayer(sel)?.first)
             val next = t?.nextPrayer(sel)
-            tvNextPrayer.text = next?.let { "Следующий намаз — ${it.first} в ${it.second}" } ?: "—"
+            tvNextPrayer.text = next?.let {
+                getString(R.string.next_prayer_time_format, it.first, it.second)
+            } ?: getString(R.string.next_prayer_placeholder)
             startTicker(next?.second, t?.tz)
         }
         vm.school.observe(this) { s ->
@@ -153,7 +156,7 @@ class MainActivity : AppCompatActivity() {
                             .heightIn(min = 180.dp),
                         contentPadding = PaddingValues(24.dp)
                     ) {
-                        Text("—", color = Color.White)
+                        Text(stringResource(R.string.placeholder_dash), color = Color.White)
                     }
                 }
             }
@@ -232,7 +235,7 @@ class MainActivity : AppCompatActivity() {
     private fun startTicker(nextTime: String?, zoneId: java.time.ZoneId?) {
         stopTicker()
         if (nextTime == null || zoneId == null) {
-            tvCountdown.text = "До начала: —"
+            tvCountdown.text = getString(R.string.countdown_placeholder)
             return
         }
         ticker = object : Runnable {
@@ -242,8 +245,8 @@ class MainActivity : AppCompatActivity() {
                     val h = it.toHours()
                     val m = (it.toMinutes() % 60)
                     val s = (it.seconds % 60)
-                    "До начала: %02d:%02d:%02d".format(h, m, s)
-                } ?: "До начала: —"
+                    getString(R.string.countdown_time_format, h, m, s)
+                } ?: getString(R.string.countdown_placeholder)
                 uiHandler.postDelayed(this, 1000)
             }
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -57,7 +57,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Asr: Standard"
+                    android:text="@string/asr_standard_button"
                     android:checked="true"
                     app:checkedIcon="@null"
                     android:checkable="true"/>
@@ -68,7 +68,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Asr: Hanafi"
+                    android:text="@string/asr_hanafi_button"
                     app:checkedIcon="@null"
                     android:checkable="true"/>
             </com.google.android.material.button.MaterialButtonToggleGroup>
@@ -85,7 +85,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Определить местоположение"/>
+                    android:text="@string/action_detect_location"/>
 
                 <Space
                     android:layout_width="8dp"
@@ -96,7 +96,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Указать город"/>
+                    android:text="@string/action_manual_city"/>
             </LinearLayout>
 
             <TextView
@@ -106,7 +106,7 @@
                 android:layout_marginTop="12dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="—"/>
+                android:text="@string/placeholder_dash"/>
 
             <TextView
                 android:id="@+id/tvDate"
@@ -114,7 +114,7 @@
                 android:layout_marginTop="2dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="—"/>
+                android:text="@string/placeholder_dash"/>
 
             <TextView
                 android:id="@+id/tvNextPrayer"
@@ -123,13 +123,13 @@
                 android:textStyle="bold"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Следующий намаз — — в —:—"/>
+                android:text="@string/next_prayer_placeholder"/>
 
             <TextView
                 android:id="@+id/tvCountdown"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="До начала: —"
+                android:text="@string/countdown_placeholder"
                 android:textSize="14sp"
                 android:layout_marginTop="4dp"/>
 

--- a/app/src/main/res/layout/item_prayer_card.xml
+++ b/app/src/main/res/layout/item_prayer_card.xml
@@ -20,7 +20,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Фаджр"
+            android:text="@string/placeholder_dash"
             android:textSize="18sp"
             android:textStyle="bold"/>
 
@@ -28,7 +28,7 @@
             android:id="@+id/tvTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="05:12"
+            android:text="@string/placeholder_time"
             android:textSize="18sp"/>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,16 @@
     <string name="asr_school_label">Мазхаб Asr</string>
     <string name="asr_school_standard">Стандарт</string>
     <string name="asr_school_hanafi">Ханафи</string>
+    <string name="asr_standard_button">Asr: Standard</string>
+    <string name="asr_hanafi_button">Asr: Hanafi</string>
+    <string name="action_detect_location">Определить местоположение</string>
+    <string name="action_manual_city">Указать город</string>
+    <string name="placeholder_dash">—</string>
+    <string name="placeholder_time">—:—</string>
+    <string name="next_prayer_placeholder">Следующий намаз — — в —:—</string>
+    <string name="next_prayer_time_format">Следующий намаз — %1$s в %2$s</string>
+    <string name="countdown_placeholder">До начала: —</string>
+    <string name="countdown_time_format">До начала: %1$02d:%2$02d:%3$02d</string>
     <string name="next_prayer_label">Следующий намаз</string>
     <string name="prayer_loading_hint">Выберите город или разрешите геолокацию, чтобы увидеть расписание.</string>
     <string name="reminder_toggle_label">Напоминание перед намазом</string>


### PR DESCRIPTION
## Summary
- remove the deprecated package attribute from the Android manifest to silence AGP warnings
- extract placeholder labels and action text into string resources and update XML layouts to reference them
- reuse the new resources from MainActivity, including Compose placeholders, to eliminate hard-coded strings

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68efed97163c832db4d7c920e7044fa1