### PR TITLE
Fix duplicate android:text attributes causing resource parse failure

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -106,7 +106,6 @@
                 android:layout_marginTop="12dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text=""/>
                 android:text="@string/placeholder_dash"/>
 
             <TextView
@@ -115,7 +114,6 @@
                 android:layout_marginTop="2dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text=""/>
                 android:text="@string/placeholder_dash"/>
 
             <TextView
@@ -125,14 +123,12 @@
                 android:textStyle="bold"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text=""/>
                 android:text="@string/next_prayer_placeholder"/>
 
             <TextView
                 android:id="@+id/tvCountdown"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text=""
                 android:text="@string/countdown_placeholder"
                 android:textSize="14sp"
                 android:layout_marginTop="4dp"/>

--- a/app/src/main/res/layout/item_prayer_card.xml
+++ b/app/src/main/res/layout/item_prayer_card.xml
@@ -20,7 +20,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text=""
             android:text="@string/placeholder_dash"
             android:textSize="18sp"
             android:textStyle="bold"/>
@@ -29,7 +28,6 @@
             android:id="@+id/tvTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text=""
             android:text="@string/placeholder_time"
             android:textSize="18sp"/>
     </LinearLayout>


### PR DESCRIPTION
## Summary
- remove duplicate `android:text` attributes in activity_main layout to restore valid XML
- clean up duplicate placeholder attributes in item prayer card layout

## Testing
- ./gradlew :app:mergeDebugResources --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f002f02bc0832daba03bd4bb39b308