### PR TITLE
Fix MainViewModel instantiation

### DIFF
--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -14,9 +14,9 @@ import java.time.ZoneId
 /**
  * Главная VM: грузит тайминги по гео или по городу, хранит выбранный мазхаб и заголовок (город/хиджра).
  */
-class MainViewModel(
+class MainViewModel : ViewModel() {
+
     private val io: CoroutineDispatcher = Dispatchers.IO
-) : ViewModel() {
 
     private val api = RetrofitProvider.aladhan
 

--- a/app/src/test/java/com/example/abys/logic/MainViewModelInstantiationTest.kt
+++ b/app/src/test/java/com/example/abys/logic/MainViewModelInstantiationTest.kt
@@ -1,0 +1,14 @@
+package com.example.abys.logic
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import org.junit.Test
+
+class MainViewModelInstantiationTest {
+    @Test
+    fun `new instance factory can construct main viewmodel`() {
+        val provider = ViewModelProvider(ViewModelStore(), ViewModelProvider.NewInstanceFactory())
+
+        provider[MainViewModel::class.java]
+    }
+}


### PR DESCRIPTION
## Summary
- move the IO dispatcher initialization into MainViewModel's body so the view model can be constructed without arguments
- this fixes the splash-to-main crash that occurred when ViewModelProvider attempted to instantiate MainViewModel

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f00c3db9d4832d90c2af3a8a2b1099