### PR TITLE
Fix countdown formatting for pre-26 devices

### DIFF
--- a/app/src/main/java/com/example/abys/ui/components/PrayerBoard.kt
+++ b/app/src/main/java/com/example/abys/ui/components/PrayerBoard.kt
@@ -197,11 +197,14 @@ private fun PrayerRow(
             timeContent()
             if (isNext && countdown != null) {
                 Spacer(Modifier.height(2.dp))
+                val hours = countdown.toHours()
+                val minutes = Math.floorMod(countdown.toMinutes(), 60)
+                val seconds = Math.floorMod(countdown.seconds, 60)
                 Text(
                     "%02d:%02d:%02d".format(
-                        countdown.toHours(),
-                        countdown.toMinutesPart(),
-                        countdown.toSecondsPart()
+                        hours,
+                        minutes,
+                        seconds
                     ),
                     color = colorResource(R.color.bm_text).copy(alpha = 0.75f),
                     style = MaterialTheme.typography.labelLarge,


### PR DESCRIPTION
## Summary
- avoid Duration.toMinutesPart/SecondsPart when rendering countdowns to keep compatibility with older Android runtimes

## Testing
- ./gradlew test *(fails: Android SDK is not available in the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68f01bf075c0832dbd5d77e1f9aec964