### PR TITLE
Fix crash from unresolved Material color attribute

### DIFF
--- a/app/src/main/res/layout/item_action_tip.xml
+++ b/app/src/main/res/layout/item_action_tip.xml
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
             android:textSize="14sp"
-            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textColor="?attr/colorOnSurface"
             android:alpha="0.8"
             android:text="" />
 

--- a/app/src/main/res/layout/view_inspiration_row.xml
+++ b/app/src/main/res/layout/view_inspiration_row.xml
@@ -4,5 +4,5 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="4dp"
     android:textSize="14sp"
-    android:textColor="?attr/colorOnSurfaceVariant"
+    android:textColor="?attr/colorOnSurface"
     android:text="" />


### PR DESCRIPTION
## Summary
- replace references to Material3 colorOnSurfaceVariant with colorOnSurface for compatibility with the app theme
- prevent runtime inflation crash when rendering fallback inspiration rows

## Testing
- ./gradlew lintDebug --console=plain *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f02b283d24832db82ab075c1501a2b