### PR TITLE
Adjust theme colors to neutral palette

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="bm_accent2">#007070</color>
     <color name="bm_outline">#444444</color>
     <color name="bm_text">#E6E6E6</color>
+    <color name="bm_status_bar">#00000000</color>
+    <color name="bm_button_light">#E0E0E0</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,13 +7,34 @@
         <item name="windowActionBar">false</item>
 
         <!-- делаем статус-бар прозрачным, нав-бар чёрным -->
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/bm_status_bar</item>
         <item name="android:navigationBarColor">@android:color/black</item>
+
+        <!-- нейтральная палитра вместо стандартного фиолетового -->
+        <item name="colorPrimary">@color/bm_button_light</item>
+        <item name="colorPrimaryVariant">@color/bm_button_light</item>
+        <item name="colorSecondary">@color/bm_button_light</item>
+        <item name="colorSecondaryVariant">@color/bm_button_light</item>
+        <item name="colorOnPrimary">@android:color/black</item>
+        <item name="colorOnSecondary">@android:color/black</item>
+        <item name="android:colorButtonNormal">@color/bm_button_light</item>
+        <item name="android:buttonStyle">@style/Widget.Abys.Button.Compat</item>
+        <item name="materialButtonStyle">@style/Widget.Abys.Button</item>
     </style>
 
     <!-- Splash: тот же набор + полноэкран -->
     <style name="Theme.Abys.NoActionBar" parent="Theme.Abys">
         <item name="android:windowFullscreen">true</item>
+    </style>
+
+    <style name="Widget.Abys.Button" parent="@style/Widget.MaterialComponents.Button">
+        <item name="backgroundTint">@color/bm_button_light</item>
+        <item name="android:textColor">@android:color/black</item>
+    </style>
+
+    <style name="Widget.Abys.Button.Compat" parent="@style/Widget.AppCompat.Button">
+        <item name="android:backgroundTint">@color/bm_button_light</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
- add explicit theme colors to remove the default purple accents
- keep the status bar transparent and use a light gray tint for button components

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0fb604d74832da8463600d6259ec1