### PR TITLE
Add animated transitions for city sheet

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -2,6 +2,14 @@
 
 package com.example.abys.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -140,7 +148,11 @@ fun MainScreen(
             if (showSheet) exploded = false
         }
 
-        if (!showSheet) {
+        AnimatedVisibility(
+            visible = !showSheet,
+            enter = fadeIn(tween(220)) + scaleIn(initialScale = 0.96f, animationSpec = tween(220)),
+            exit = fadeOut(tween(180)) + scaleOut(targetScale = 0.96f, animationSpec = tween(180))
+        ) {
             PrayerCard(
                 times = prayerTimes,
                 thirds = thirds,
@@ -170,7 +182,11 @@ fun MainScreen(
                 .padding(bottom = (48f * sy).dp)
         )
 
-        if (showSheet) {
+        AnimatedVisibility(
+            visible = showSheet,
+            enter = fadeIn(tween(220)) + slideInHorizontally(initialOffsetX = { it / 6 }, animationSpec = tween(220)),
+            exit = fadeOut(tween(180)) + slideOutHorizontally(targetOffsetX = { it / 6 }, animationSpec = tween(180))
+        ) {
             CitySheet(
                 city = city,
                 hadith = hadith,


### PR DESCRIPTION
## Summary
- add animated visibility transitions so the prayer card fades out and the city sheet glides in when toggled

## Testing
- ./gradlew test (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68f1028b34b8832db73428179083c7a1