### PR TITLE
Refine effect carousel selection

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -1,6 +1,9 @@
 package com.example.abys.ui.screen
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.animateDecay
+import androidx.compose.animation.core.rememberSplineBasedDecay
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -24,7 +27,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.consume
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -65,6 +70,8 @@ fun CityPickerWheel(
         mutableStateOf(cities.indexOf(currentCity).takeIf { it >= 0 } ?: 0)
     }
     val offsetY = remember { Animatable(0f) }
+    val decay = rememberSplineBasedDecay<Float>()
+    val velocityTracker = remember { VelocityTracker() }
 
     LaunchedEffect(currentCity, cities) {
         val idx = cities.indexOf(currentCity).takeIf { it >= 0 } ?: 0
@@ -72,14 +79,36 @@ fun CityPickerWheel(
         offsetY.snapTo(0f)
     }
 
-    fun snap() {
+    suspend fun accumulate(delta: Float) {
+        val newOffset = offsetY.value + delta
+        val steps = (newOffset / stepPx).toInt()
+        if (steps != 0) {
+            centerIndex = (centerIndex - steps).floorMod(cities.size)
+        }
+        offsetY.snapTo(newOffset - steps * stepPx)
+    }
+
+    suspend fun snap() {
+        val deltaSteps = (offsetY.value / stepPx).roundToInt()
+        if (deltaSteps != 0) {
+            centerIndex = (centerIndex - deltaSteps).floorMod(cities.size)
+        }
+        offsetY.animateTo(0f)
+        onChosen(cities[centerIndex])
+    }
+
+    fun settle(velocity: Float) {
         scope.launch {
-            val deltaSteps = (offsetY.value / stepPx).roundToInt()
-            if (deltaSteps != 0) {
-                centerIndex = (centerIndex - deltaSteps).floorMod(cities.size)
+            offsetY.stop()
+            if (abs(velocity) > 50f) {
+                var lastValue = 0f
+                AnimationState(initialValue = 0f, initialVelocity = velocity).animateDecay(decay) {
+                    val delta = value - lastValue
+                    lastValue = value
+                    accumulate(delta)
+                }
             }
-            offsetY.animateTo(0f)
-            onChosen(cities[centerIndex])
+            snap()
         }
     }
 
@@ -89,11 +118,21 @@ fun CityPickerWheel(
             .clipToBounds()
             .pointerInput(cities, centerIndex) {
                 detectVerticalDragGestures(
-                    onDragEnd = { snap() },
-                    onDragCancel = { snap() }
-                ) { _, dragAmount ->
-                    offsetY.snapTo(offsetY.value + dragAmount)
-                }
+                    onDragStart = {
+                        velocityTracker.reset()
+                        scope.launch { offsetY.stop() }
+                    },
+                    onVerticalDrag = { change, dragAmount ->
+                        change.consume()
+                        velocityTracker.addPosition(change.uptimeMillis, change.position)
+                        accumulate(dragAmount)
+                    },
+                    onDragEnd = {
+                        val velocity = velocityTracker.calculateVelocity().y
+                        settle(velocity)
+                    },
+                    onDragCancel = { settle(0f) }
+                )
             }
             .drawWithContent {
                 drawContent()

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -2,11 +2,16 @@
 
 package com.example.abys.ui.screen
 
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +21,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,13 +38,16 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -55,7 +64,11 @@ import com.example.abys.ui.util.backdropBlur
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
+import kotlin.math.exp
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+
+private enum class SurfaceStage { Dashboard, CitySheet, CityPicker }
 
 @Composable
 fun MainApp(vm: MainViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
@@ -67,6 +80,7 @@ fun MainApp(vm: MainViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
     )
     val showSheet by vm.sheetVisible.observeAsState(false)
     val showPicker by vm.pickerVisible.observeAsState(false)
+    val selectedEffect by vm.selectedEffect.observeAsState(null)
     val hadith by vm.hadithToday.observeAsState("")
     val effects = remember {
         listOf(
@@ -90,6 +104,7 @@ fun MainApp(vm: MainViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
             prayerTimes = times,
             thirds = thirds,
             effects = effects,
+            selectedEffect = selectedEffect,
             showSheet = showSheet,
             showPicker = showPicker,
             hadith = hadith,
@@ -109,6 +124,7 @@ fun MainScreen(
     prayerTimes: Map<String, String>,
     thirds: Triple<String, String, String>,
     effects: List<Int>,
+    selectedEffect: Int?,
     showSheet: Boolean,
     showPicker: Boolean,
     hadith: String,
@@ -120,6 +136,89 @@ fun MainScreen(
 ) {
     val sx = Dimens.sx()
     val sy = Dimens.sy()
+    val density = LocalDensity.current
+
+    val stage = when {
+        !showSheet -> SurfaceStage.Dashboard
+        showPicker -> SurfaceStage.CityPicker
+        else -> SurfaceStage.CitySheet
+    }
+
+    val transition = updateTransition(stage, label = "surface")
+    val sheetHiddenOffset = with(density) { (236f * sx).dp.toPx() }
+    val sheetLift = with(density) { (18f * sy).dp.toPx() }
+    val cardLift = with(density) { (42f * sy).dp.toPx() }
+    val carouselDrop = with(density) { (36f * sy).dp.toPx() }
+    val headerLift = with(density) { (14f * sy).dp.toPx() }
+
+    val prayerAlpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = if (targetState == SurfaceStage.Dashboard) 200 else 240) },
+        label = "prayerAlpha"
+    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0f }
+    val prayerScale by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 260) },
+        label = "prayerScale"
+    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.94f }
+    val prayerTranslation by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 240) },
+        label = "prayerTranslation"
+    ) { st -> if (st == SurfaceStage.Dashboard) 0f else -cardLift }
+
+    val headerAlpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 220) },
+        label = "headerAlpha"
+    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.82f }
+    val headerTranslation by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 220) },
+        label = "headerTranslation"
+    ) { st -> if (st == SurfaceStage.Dashboard) 0f else -headerLift }
+
+    val carouselAlpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 220) },
+        label = "carouselAlpha"
+    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.45f }
+    val carouselScale by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 240) },
+        label = "carouselScale"
+    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.92f }
+    val carouselTranslation by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 240) },
+        label = "carouselTranslation"
+    ) { st -> if (st == SurfaceStage.Dashboard) 0f else carouselDrop }
+
+    val scrimAlpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 220) },
+        label = "scrimAlpha"
+    ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
+
+    val sheetAlpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 240) },
+        label = "sheetAlpha"
+    ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
+    val sheetTranslationX by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 260) },
+        label = "sheetTranslationX"
+    ) { st -> if (st == SurfaceStage.Dashboard) sheetHiddenOffset else 0f }
+    val sheetTranslationY by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 260) },
+        label = "sheetTranslationY"
+    ) { st ->
+        when (st) {
+            SurfaceStage.Dashboard -> sheetLift
+            SurfaceStage.CitySheet -> 0f
+            SurfaceStage.CityPicker -> -sheetLift / 2f
+        }
+    }
+    val sheetScale by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 260) },
+        label = "sheetScale"
+    ) { st ->
+        when (st) {
+            SurfaceStage.Dashboard -> 0.9f
+            SurfaceStage.CitySheet -> 1f
+            SurfaceStage.CityPicker -> 1.04f
+        }
+    }
 
     Box(Modifier.fillMaxSize()) {
         HeaderPill(
@@ -131,34 +230,46 @@ fun MainScreen(
                     top = (79f * sy).dp,
                     end = (51f * sx).dp
                 )
-                .height((102f * sy).dp),
+                .height((102f * sy).dp)
+                .graphicsLayer {
+                    alpha = headerAlpha
+                    translationY = headerTranslation
+                },
             onTap = onCityPillClick
         )
 
         var exploded by remember { mutableStateOf(false) }
-        LaunchedEffect(showSheet) {
-            if (showSheet) exploded = false
+        LaunchedEffect(stage) {
+            if (stage != SurfaceStage.Dashboard) exploded = false
         }
 
-        if (!showSheet) {
+        val prayerModifier = Modifier
+            .padding(
+                start = (64f * sx).dp,
+                end = (64f * sx).dp,
+                top = (226f * sy).dp
+            )
+            .height((611f * sy).dp)
+            .graphicsLayer {
+                val explodedAlpha = if (exploded) 0f else 1f
+                val explodedScale = if (exploded) 1.08f else 1f
+                alpha = prayerAlpha * explodedAlpha
+                scaleX = prayerScale * explodedScale
+                scaleY = prayerScale * explodedScale
+                translationY = prayerTranslation
+            }
+
+        if (prayerAlpha > 0.01f) {
             PrayerCard(
                 times = prayerTimes,
                 thirds = thirds,
-                modifier = Modifier
-                    .padding(
-                        start = (64f * sx).dp,
-                        end = (64f * sx).dp,
-                        top = (226f * sy).dp
-                    )
-                    .height((611f * sy).dp)
-                    .pointerInput(Unit) {
+                modifier = if (stage == SurfaceStage.Dashboard) {
+                    prayerModifier.pointerInput(Unit) {
                         detectTapGestures(onDoubleTap = { exploded = !exploded })
                     }
-                    .graphicsLayer {
-                        alpha = if (exploded) 0f else 1f
-                        scaleX = if (exploded) 1.1f else 1f
-                        scaleY = if (exploded) 1.1f else 1f
-                    }
+                } else {
+                    prayerModifier
+                }
             )
         }
 
@@ -168,9 +279,31 @@ fun MainScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = (48f * sy).dp)
+                .graphicsLayer {
+                    alpha = carouselAlpha
+                    scaleX = carouselScale
+                    scaleY = carouselScale
+                    translationY = carouselTranslation
+                },
+            selected = selectedEffect,
+            interactionEnabled = stage == SurfaceStage.Dashboard
         )
 
-        if (showSheet) {
+        if (scrimAlpha > 0.01f) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { alpha = scrimAlpha }
+                    .background(Color.Black.copy(alpha = 0.5f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onCityPillClick
+                    )
+            )
+        }
+
+        if (sheetAlpha > 0.01f) {
             CitySheet(
                 city = city,
                 hadith = hadith,
@@ -178,7 +311,15 @@ fun MainScreen(
                 pickerVisible = showPicker,
                 onCityChipTap = onCityChipTap,
                 onCityChosen = onCityChosen,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        alpha = sheetAlpha
+                        translationX = sheetTranslationX
+                        translationY = sheetTranslationY
+                        scaleX = sheetScale
+                        scaleY = sheetScale
+                    }
             )
         }
     }
@@ -418,17 +559,66 @@ private fun Tick(height: Dp) {
 private fun EffectCarousel(
     items: List<Int>,
     onTap: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    interactionEnabled: Boolean = true,
+    selected: Int? = null
 ) {
     val sx = Dimens.sx()
     val sy = Dimens.sy()
     val state = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val spacing = (40f * sx).dp
+    val borderWidth = (3f * Dimens.s()).dp
+    val thumbShape = RoundedCornerShape(Tokens.Radii.chip())
+
+    LaunchedEffect(state, items, interactionEnabled) {
+        if (!interactionEnabled) return@LaunchedEffect
+        snapshotFlow { state.isScrollInProgress }
+            .collectLatest { isScrolling ->
+                if (!isScrolling) {
+                    val layoutInfo = state.layoutInfo
+                    if (layoutInfo.totalItemsCount == 0 || layoutInfo.viewportSize.width == 0) return@collectLatest
+                    val viewportCenter = layoutInfo.viewportSize.width / 2f
+                    val closest = layoutInfo.visibleItemsInfo.minByOrNull { info ->
+                        abs(info.offset + info.size / 2f - viewportCenter)
+                    } ?: return@collectLatest
+                    val targetCenter = closest.offset + closest.size / 2f
+                    val delta = viewportCenter - targetCenter
+                    if (abs(delta) > 1f) {
+                        state.animateScrollBy(delta)
+                    }
+                }
+            }
+    }
+
+    LaunchedEffect(selected, interactionEnabled, items) {
+        if (!interactionEnabled) return@LaunchedEffect
+        val targetIndex = selected?.let(items::indexOf) ?: -1
+        if (targetIndex < 0) return@LaunchedEffect
+        val layoutInfo = state.layoutInfo
+        if (layoutInfo.totalItemsCount == 0 || layoutInfo.viewportSize.width == 0) return@LaunchedEffect
+        val viewportCenter = layoutInfo.viewportSize.width / 2f
+        val closest = layoutInfo.visibleItemsInfo.minByOrNull { info ->
+            abs(info.offset + info.size / 2f - viewportCenter)
+        }
+        if (closest?.index == targetIndex && abs(viewportCenter - (closest.offset + closest.size / 2f)) <= 1f) {
+            return@LaunchedEffect
+        }
+        val targetVisible = layoutInfo.visibleItemsInfo.firstOrNull { it.index == targetIndex }
+        if (targetVisible != null) {
+            val delta = viewportCenter - (targetVisible.offset + targetVisible.size / 2f)
+            if (abs(delta) > 1f) {
+                state.animateScrollBy(delta)
+            }
+        } else {
+            state.animateScrollToItem(targetIndex)
+        }
+    }
 
     Box(modifier) {
         LazyRow(
             state = state,
+            userScrollEnabled = interactionEnabled,
             horizontalArrangement = Arrangement.spacedBy(spacing),
             contentPadding = PaddingValues(horizontal = spacing)
         ) {
@@ -437,25 +627,23 @@ private fun EffectCarousel(
                 val center = info?.let { it.offset + it.size / 2f }
                 val viewportCenter = state.layoutInfo.viewportSize.width / 2f
                 val distance = if (center != null) abs(center - viewportCenter) else Float.MAX_VALUE
-                val (scale, alpha) = when {
-                    distance < 40f -> 1f to 1f
-                    distance < 150f -> 0.85f to 0.7f
-                    else -> 0.75f to 0.5f
-                }
+                val normalized = if (viewportCenter <= 0f || center == null) 1f else (distance / viewportCenter).coerceIn(0f, 1.35f)
+                val baseScale = 0.78f + 0.22f * exp(-(normalized * 2.4f))
+                val baseAlpha = 0.45f + 0.55f * exp(-(normalized * 2.1f))
+                val isSelected = selected == res
+                val displayScale = (baseScale + if (isSelected) 0.06f else 0f).coerceIn(0.7f, 1.12f)
+                val displayAlpha = if (isSelected) 1f else baseAlpha
 
-                Image(
-                    painter = painterResource(res),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
+                Box(
                     modifier = Modifier
                         .size(width = (121f * sx).dp, height = (153f * sy).dp)
                         .graphicsLayer {
-                            this.scaleX = scale
-                            this.scaleY = scale
-                            this.alpha = alpha
+                            this.scaleX = displayScale
+                            this.scaleY = displayScale
+                            this.alpha = displayAlpha
                         }
-                        .clip(RoundedCornerShape(Tokens.Radii.chip()))
-                        .clickable {
+                        .clip(thumbShape)
+                        .clickable(enabled = interactionEnabled) {
                             info?.let {
                                 val target = center ?: return@let
                                 scope.launch {
@@ -464,7 +652,22 @@ private fun EffectCarousel(
                             }
                             onTap(res)
                         }
-                )
+                ) {
+                    Image(
+                        painter = painterResource(res),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+
+                    if (isSelected) {
+                        Box(
+                            Modifier
+                                .matchParentSize()
+                                .border(borderWidth, Color.White.copy(alpha = 0.9f), thumbShape)
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add spline-based decay animation and velocity tracking so the city picker wheel responds with inertial flings
- refactor offset accumulation to keep the active index centred while animating and snap to the nearest city at rest
- surface the selected effect in MainScreen, auto-centre the carousel when a theme is restored, and highlight the active tile with a glass border

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1028b34b8832db73428179083c7a1