### PR TITLE
Implement effect carousel with persisted selection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,10 +50,12 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.compose.runtime:runtime-saveable")
-    implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.foundation:foundation-layout")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
+
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.compose.foundation:foundation:1.6.8")
 
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")

--- a/app/src/main/java/com/example/abys/data/EffectRepository.kt
+++ b/app/src/main/java/com/example/abys/data/EffectRepository.kt
@@ -1,0 +1,29 @@
+package com.example.abys.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.effectDataStore by preferencesDataStore(name = "abys_effects")
+
+enum class EffectId { leaves, lightning, night, rain, snow, storm, sunset_snow, wind }
+
+class EffectRepository(private val appContext: Context) {
+
+    private val keyEffect = stringPreferencesKey("effect_id")
+
+    val selectedEffect: Flow<EffectId> =
+        appContext.effectDataStore.data.map { prefs ->
+            val stored = prefs[keyEffect]
+            stored?.let { runCatching { EffectId.valueOf(it) }.getOrNull() } ?: EffectId.night
+        }
+
+    suspend fun setEffect(id: EffectId) {
+        appContext.effectDataStore.edit { prefs ->
+            prefs[keyEffect] = id.name
+        }
+    }
+}

--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -67,9 +67,6 @@ class MainViewModel : ViewModel() {
     private val _clock = MutableLiveData(LocalTime.now().format(timeFormatter))
     val clock: LiveData<String> = _clock
 
-    private val _selectedEffect = MutableLiveData<Int?>(null)
-    val selectedEffect: LiveData<Int?> = _selectedEffect
-
     init {
         viewModelScope.launch {
             while (true) {
@@ -113,10 +110,6 @@ class MainViewModel : ViewModel() {
         _pickerVisible.value = false
         _sheetVisible.value = false
         loadByCity(c)
-    }
-
-    fun setEffect(effectRes: Int) {
-        _selectedEffect.value = effectRes
     }
 
     fun loadSavedSchool(ctx: Context) {

--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -1,0 +1,219 @@
+package com.example.abys.ui
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.abys.data.EffectId
+import kotlin.math.abs
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+// Data class representing the thumbnail and its corresponding effect id.
+data class EffectThumb(val id: EffectId, @DrawableRes val resId: Int)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun EffectCarousel(
+    modifier: Modifier = Modifier,
+    items: List<EffectThumb>,
+    selected: EffectId,
+    onSelected: (EffectId) -> Unit,
+    enabled: Boolean = true
+) {
+    val cardWidth: Dp = 121.dp
+    val cardHeight: Dp = 153.dp
+    val cardRadius = 22.dp
+    val itemSpacing = 40.dp
+
+    val listState = rememberLazyListState()
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+    val scope = rememberCoroutineScope()
+
+    var viewportWidthPx by remember { mutableStateOf(0) }
+
+    val sidePadding = cardWidth / 2 + itemSpacing
+
+    LaunchedEffect(items, selected, viewportWidthPx) {
+        if (viewportWidthPx == 0) return@LaunchedEffect
+        val targetIndex = items.indexOfFirst { it.id == selected }
+        if (targetIndex < 0) return@LaunchedEffect
+        val currentIndex = nearestCenterIndex(listState, viewportWidthPx)
+        if (currentIndex == targetIndex) {
+            val delta = listState.calculateCenteringDelta(viewportWidthPx)
+            if (delta != null && abs(delta) > 0.5f) {
+                listState.scrollBy(delta)
+            }
+        } else {
+            listState.animateScrollToItem(targetIndex)
+        }
+    }
+
+    LaunchedEffect(listState, viewportWidthPx, items, enabled) {
+        if (viewportWidthPx == 0) return@LaunchedEffect
+        snapshotFlow { listState.isScrollInProgress }
+            .filter { !it }
+            .collectLatest {
+                val delta = listState.calculateCenteringDelta(viewportWidthPx)
+                if (delta != null && abs(delta) > 0.5f) {
+                    listState.animateScrollBy(delta)
+                    return@collectLatest
+                }
+                if (!enabled) return@collectLatest
+                val index = nearestCenterIndex(listState, viewportWidthPx)
+                val effect = items.getOrNull(index)?.id ?: return@collectLatest
+                if (effect != selected) {
+                    onSelected(effect)
+                }
+            }
+    }
+
+    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        LazyRow(
+            state = listState,
+            flingBehavior = flingBehavior,
+            userScrollEnabled = enabled,
+            contentPadding = PaddingValues(horizontal = sidePadding),
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(itemSpacing),
+            modifier = Modifier
+                .fillMaxWidth()
+                .onGloballyPositioned { viewportWidthPx = it.size.width }
+        ) {
+            itemsIndexed(items) { index, item ->
+                val distance = distanceToCenter(index, listState, viewportWidthPx)
+                val scale = scaleForDistance(distance)
+                val alpha = alphaForDistance(distance)
+
+                Card(
+                    modifier = Modifier
+                        .size(cardWidth, cardHeight)
+                        .graphicsLayer {
+                            scaleX = scale
+                            scaleY = scale
+                        }
+                        .alpha(alpha),
+                    shape = RoundedCornerShape(cardRadius),
+                    colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                    onClick = {
+                        if (!enabled) return@Card
+                        scope.launch {
+                            listState.animateScrollToItem(index)
+                            if (selected != item.id) {
+                                onSelected(item.id)
+                            }
+                        }
+                    }
+                ) {
+                    Image(
+                        painter = painterResource(item.resId),
+                        contentDescription = item.id.name,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.matchParentSize()
+                    )
+
+                    if (item.id == selected) {
+                        Box(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .border(
+                                    width = 2.dp,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f),
+                                    shape = RoundedCornerShape(cardRadius)
+                                )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun distanceToCenter(
+    index: Int,
+    listState: LazyListState,
+    viewportWidthPx: Int
+): Float {
+    if (viewportWidthPx == 0) return Float.MAX_VALUE
+    val layoutInfo = listState.layoutInfo
+    val visible = layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+        ?: return Float.MAX_VALUE
+    val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
+    val itemCenter = visible.offset + visible.size / 2f
+    val itemExtent = visible.size.takeIf { it > 0 } ?: return Float.MAX_VALUE
+    return abs(itemCenter - viewportCenter) / itemExtent.toFloat()
+}
+
+private fun nearestCenterIndex(listState: LazyListState, viewportWidthPx: Int): Int {
+    val layout = listState.layoutInfo
+    if (layout.totalItemsCount == 0) return 0
+    val viewportCenter = (layout.viewportStartOffset + layout.viewportEndOffset) / 2f
+    return layout.visibleItemsInfo.minByOrNull { info ->
+        val itemCenter = info.offset + info.size / 2f
+        abs(itemCenter - viewportCenter)
+    }?.index ?: listState.firstVisibleItemIndex
+}
+
+private fun LazyListState.calculateCenteringDelta(viewportWidthPx: Int): Float? {
+    val layout = layoutInfo
+    if (layout.visibleItemsInfo.isEmpty()) return null
+    val viewportCenter = (layout.viewportStartOffset + layout.viewportEndOffset) / 2f
+    val closest = layout.visibleItemsInfo.minByOrNull { info ->
+        val itemCenter = info.offset + info.size / 2f
+        abs(itemCenter - viewportCenter)
+    } ?: return null
+    val itemCenter = closest.offset + closest.size / 2f
+    return viewportCenter - itemCenter
+}
+
+private fun scaleForDistance(distance: Float): Float {
+    if (distance == Float.MAX_VALUE) return 0.75f
+    return when {
+        distance <= 1f -> lerp(1f, 0.85f, distance.coerceIn(0f, 1f))
+        else -> lerp(0.85f, 0.75f, (distance - 1f).coerceIn(0f, 1f))
+    }
+}
+
+private fun alphaForDistance(distance: Float): Float {
+    if (distance == Float.MAX_VALUE) return 0.5f
+    return when {
+        distance <= 1f -> lerp(1f, 0.7f, distance.coerceIn(0f, 1f))
+        else -> lerp(0.7f, 0.5f, (distance - 1f).coerceIn(0f, 1f))
+    }
+}
+
+private fun lerp(start: Float, end: Float, fraction: Float): Float {
+    return start + (end - start) * fraction
+}

--- a/app/src/main/java/com/example/abys/ui/EffectViewModel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.abys.ui
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.abys.data.EffectId
+import com.example.abys.data.EffectRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class EffectViewModel(app: Application) : AndroidViewModel(app) {
+    private val repository = EffectRepository(app)
+
+    val effect: StateFlow<EffectId> = repository.selectedEffect
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), EffectId.night)
+
+    fun onEffectSelected(id: EffectId) {
+        viewModelScope.launch { repository.setEffect(id) }
+    }
+}

--- a/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
+++ b/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
@@ -1,0 +1,11 @@
+package com.example.abys.ui.background
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.example.abys.data.EffectId
+
+@Composable
+fun BackgroundHost(effect: EffectId) {
+    val backgrounds = remember(effect) { ThemeBackgrounds.backgroundsFor(effect) }
+    SlideshowBackground(images = backgrounds)
+}

--- a/app/src/main/java/com/example/abys/ui/background/ThemeBackgrounds.kt
+++ b/app/src/main/java/com/example/abys/ui/background/ThemeBackgrounds.kt
@@ -1,54 +1,69 @@
 package com.example.abys.ui.background
 
 import com.example.abys.R
+import com.example.abys.data.EffectId
+import com.example.abys.ui.EffectThumb
 
 /**
  * Maps carousel thumbnails to the slideshow image sets.
  * If a theme has no dedicated backgrounds yet, we fall back to the default slide deck.
  */
 object ThemeBackgrounds {
-    private data class Entry(val thumb: Int, val backgrounds: List<Int>)
+    private data class Entry(
+        val id: EffectId,
+        val thumb: Int,
+        val backgrounds: List<Int>
+    )
 
     private val entries = listOf(
         Entry(
+            id = EffectId.leaves,
             thumb = R.drawable.thumb_leaves,
             backgrounds = listOf(R.drawable.slide_01, R.drawable.slide_02)
         ),
         Entry(
+            id = EffectId.lightning,
             thumb = R.drawable.thumb_lightning,
             backgrounds = listOf(R.drawable.slide_03, R.drawable.slide_07)
         ),
         Entry(
+            id = EffectId.night,
             thumb = R.drawable.thumb_night,
             backgrounds = listOf(R.drawable.slide_04, R.drawable.slide_08)
         ),
         Entry(
+            id = EffectId.rain,
             thumb = R.drawable.thumb_rain,
             backgrounds = listOf(R.drawable.slide_05)
         ),
         Entry(
+            id = EffectId.snow,
             thumb = R.drawable.thumb_snow,
             backgrounds = listOf(R.drawable.slide_06)
         ),
         Entry(
+            id = EffectId.storm,
             thumb = R.drawable.thumb_storm,
             backgrounds = listOf(R.drawable.slide_07, R.drawable.slide_03)
         ),
         Entry(
+            id = EffectId.sunset_snow,
             thumb = R.drawable.thumb_sunset_snow,
             backgrounds = listOf(R.drawable.slide_08, R.drawable.slide_02)
         ),
         Entry(
+            id = EffectId.wind,
             thumb = R.drawable.thumb_wind,
             backgrounds = listOf(R.drawable.slide_01, R.drawable.slide_05)
         )
     )
 
-    val thumbnails: List<Int> = entries.map(Entry::thumb)
+    val thumbnails: List<EffectThumb> = entries.map { entry ->
+        EffectThumb(entry.id, entry.thumb)
+    }
 
-    fun backgroundsFor(effectThumb: Int?): List<Int> {
-        if (effectThumb == null) return Slides.all
-        val backgrounds = entries.firstOrNull { it.thumb == effectThumb }?.backgrounds
+    fun backgroundsFor(effect: EffectId): List<Int> {
+        val backgrounds = entries.firstOrNull { it.id == effect }?.backgrounds
         return if (backgrounds.isNullOrEmpty()) Slides.all else backgrounds
     }
 }

--- a/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/LeavesEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the animated leaves background.
+ * TODO: implement particle system for falling leaves.
+ */
+object LeavesEffect

--- a/app/src/main/java/com/example/abys/ui/effects/LightningEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/LightningEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the lightning background effect.
+ * TODO: replace with real-time lightning shader.
+ */
+object LightningEffect

--- a/app/src/main/java/com/example/abys/ui/effects/NightEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/NightEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the calm night sky effect.
+ * TODO: implement star field animation.
+ */
+object NightEffect

--- a/app/src/main/java/com/example/abys/ui/effects/RainEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/RainEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the animated rain background.
+ * TODO: render raindrop streak animation.
+ */
+object RainEffect

--- a/app/src/main/java/com/example/abys/ui/effects/SnowEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/SnowEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the snowfall effect.
+ * TODO: render layered drifting snow particles.
+ */
+object SnowEffect

--- a/app/src/main/java/com/example/abys/ui/effects/StormEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/StormEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the heavy storm effect.
+ * TODO: add dark clouds, wind gusts, and flashes.
+ */
+object StormEffect

--- a/app/src/main/java/com/example/abys/ui/effects/SunsetSnowEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/SunsetSnowEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the sunset over snow effect.
+ * TODO: compose warm gradient over subtle snow drift animation.
+ */
+object SunsetSnowEffect

--- a/app/src/main/java/com/example/abys/ui/effects/WindEffect.kt
+++ b/app/src/main/java/com/example/abys/ui/effects/WindEffect.kt
@@ -1,0 +1,7 @@
+package com.example.abys.ui.effects
+
+/**
+ * Placeholder for the wind effect.
+ * TODO: create flowing air currents and drifting particles.
+ */
+object WindEffect


### PR DESCRIPTION
## Summary
- add a DataStore-backed repository and view model to persist the selected background effect
- implement the snap-based effect carousel with scale and alpha falloffs plus selection callbacks
- crossfade the main background per effect, map thumbnails to slides, and add placeholders for all future effect animations

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f125ad9ff8832d9d775cb275649ca1