### PR TITLE
Raise minSdk to 27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.abys"
-        minSdk = 23
+        minSdk = 27
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
@@ -96,7 +96,7 @@ dependencies {
 
     implementation("com.google.accompanist:accompanist-permissions:0.36.0")
 
-    // java.time на API 23
+    // Дополнительные библиотеки десугаринга для поддержки java.time и других API
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     // Testing


### PR DESCRIPTION
## Summary
- raise the Android module minSdk level to 27 to match the new baseline
- update the desugaring dependency comment to reflect its broader purpose

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f138f21ed4832dade74d85429dd8ad