### PR TITLE
Add missing AAPT namespace to launcher background drawable

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"
     android:height="108dp"
     android:viewportWidth="108"


### PR DESCRIPTION
## Summary
- declare the missing `xmlns:aapt` namespace on the launcher background vector so the embedded gradient attribute parses correctly

## Testing
- ./gradlew :app:mergeDebugResources --quiet *(fails: duplicate drawable resources already present in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f153778fb4832d838cd1ce43a82a5c