### PR TITLE
Fix launcher background vector to use solid fill

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -6,19 +6,10 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
-    <!-- Градиентный фон: сверху светло-синий, к низу — серо-зеленый -->
+    <!-- Однородный фон: плавный пастельный оттенок вместо градиента -->
     <path
         android:pathData="M0,0h108v108h-108z"
-        android:fillColor="@android:color/transparent">
-        <aapt:attr name="android:fillColor">
-            <gradient
-                android:type="linear"
-                android:startY="0"
-                android:endY="108"
-                android:startColor="#E7F7FE"
-                android:endColor="#BEE7E2"/>
-        </aapt:attr>
-    </path>
+        android:fillColor="#D7F0F4"/>
 
     <!-- Central soft blur/circle -->
     <path


### PR DESCRIPTION
## Summary
- replace the unsupported gradient fill in `ic_launcher_background.xml` with a solid color so the launcher background vector compiles

## Testing
- `./gradlew :app:mergeDebugResources --no-daemon --console=plain` *(fails: existing duplicate drawable resource definitions in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f156581d84832da82f1bd9563387ac