### PR TITLE
Fix Compose API usages causing compilation errors

### DIFF
--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -7,10 +7,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.animateScrollBy
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -39,6 +40,7 @@ import com.example.abys.ui.theme.Tokens
 import com.example.abys.data.EffectId
 import kotlin.math.abs
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.scrollBy
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
@@ -143,13 +145,13 @@ fun EffectCarousel(
                         painter = painterResource(item.resId),
                         contentDescription = item.id.name,
                         contentScale = ContentScale.Crop,
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     )
 
                     if (item.id == selected) {
                         Box(
                             modifier = Modifier
-                                .matchParentSize()
+                                .fillMaxSize()
                                 .border(
                                     width = 2.dp,
                                     color = Tokens.Colors.separator,
@@ -222,10 +224,10 @@ private fun lerp(start: Float, end: Float, fraction: Float): Float {
 
 private suspend fun LazyListState.scrollByCompat(distance: Float) {
     if (distance == 0f) return
-    scroll { scrollBy(distance) }
+    scrollBy(distance)
 }
 
 private suspend fun LazyListState.animateScrollByCompat(distance: Float) {
     if (distance == 0f) return
-    animateScroll { scrollBy(distance) }
+    animateScrollBy(distance)
 }

--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -91,7 +90,7 @@ fun CityPickerWheel(
 
         Box(
             Modifier
-                .matchParentSize()
+                .fillMaxSize()
                 .drawWithContent {
                     drawContent()
                     if (size.height <= 0f) return@drawWithContent

--- a/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
@@ -106,7 +106,11 @@ fun CitySheet(
                     fontStyle  = FontStyle.Italic,
                     fontWeight = FontWeight.Bold,
                     color      = Tokens.Colors.text,
-                    shadow     = Shadow(Tokens.Colors.tickDark.copy(alpha = 0.35f), offset = Offset(0f, 2f), blurRadius = 4f)
+                    shadow     = Shadow(
+                        Tokens.Colors.tickDark.copy(alpha = 0.35f),
+                        offset = Offset(0f, 2f),
+                        blurRadius = 4f
+                    )
                 ),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
@@ -168,9 +172,13 @@ private fun HadithFrame(
                     fontWeight = FontWeight.Bold,
                     color      = Tokens.Colors.text,
                     lineHeight = 1.42.em,
-                    shadow     = Shadow(Tokens.Colors.tickDark.copy(alpha = 0.35f), offset = Offset(0f, 2f), blurRadius = 6f)
-                ),
-                textAlign = TextAlign.Start
+                    textAlign = TextAlign.Start,
+                    shadow     = Shadow(
+                        Tokens.Colors.tickDark.copy(alpha = 0.35f),
+                        offset = Offset(0f, 2f),
+                        blurRadius = 6f
+                    )
+                )
             )
         }
     }

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -29,14 +29,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.provides
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -45,7 +47,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.LocalTextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign


### PR DESCRIPTION
## Summary
- replace matchParentSize calls with fillMaxSize so components compile with the current Compose libraries
- switch LazyListState helpers to the standard scrollBy/animateScrollBy extensions
- fix CitySheet BasicText configuration and use the Material3 LocalTextStyle provider

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1628030b8832da45dc15b97134461