### PR TITLE
Fix Compose carousel imports and close MainScreen scope

### DIFF
--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -4,6 +4,8 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.animateScrollBy
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -40,7 +41,6 @@ import com.example.abys.ui.theme.Tokens
 import com.example.abys.data.EffectId
 import kotlin.math.abs
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.scrollBy
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.provides
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -339,6 +338,7 @@ fun MainScreen(
                 )
             }
         }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- import the LazyList scroll helpers from the gestures package to restore EffectCarousel extensions
- clean up MainScreen by removing the invalid provides import and closing the composable scope so helper composables resolve

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f165883794832dacf576ed0824c536