### PR TITLE
Refine glass UI layering and carousel behaviour

### DIFF
--- a/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
+++ b/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
@@ -98,16 +98,14 @@ fun SlideshowBackground(
     val driftPhase = (nowMs % 16000L) / 16000f
     val driftX = sin(driftPhase * 2f * PI).toFloat() * 12f
     val driftY = cos(driftPhase * 2f * PI).toFloat() * 8f
-    val baseScale = 1.04f
-
     val progress = (within / period).toFloat().coerceIn(0f, 1f)
-    val topAlpha = 0.06f + 0.06f * progress
-    val bottomAlpha = 0.18f + 0.06f * (1f - kotlin.math.abs(progress - 0.5f) * 2f)
+    val topAlpha = 0.08f + 0.04f * progress
+    val bottomAlpha = 0.12f + 0.05f * (1f - abs(progress - 0.5f) * 2f)
 
     Box(
         modifier
             .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.1f)),
+            .background(Color.Black),
         contentAlignment = Alignment.Center
     ) {
         // Рисуем до трёх слоёв для аккуратного кросс-фейда
@@ -120,12 +118,10 @@ fun SlideshowBackground(
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
                     alpha = alphaPrev
-                    scaleX = baseScale
-                    scaleY = baseScale
                     translationX = driftX
                     translationY = driftY
                 },
-                contentScale = ContentScale.Fit
+                contentScale = ContentScale.Crop
             )
         }
         Image(
@@ -133,12 +129,10 @@ fun SlideshowBackground(
             contentDescription = null,
             modifier = imageModifier.graphicsLayer {
                 alpha = alphaCurr
-                scaleX = baseScale
-                scaleY = baseScale
                 translationX = driftX
                 translationY = driftY
             },
-            contentScale = ContentScale.Fit
+            contentScale = ContentScale.Crop
         )
         if (alphaNext > 0f) {
             Image(
@@ -146,12 +140,10 @@ fun SlideshowBackground(
                 contentDescription = null,
                 modifier = imageModifier.graphicsLayer {
                     alpha = alphaNext
-                    scaleX = baseScale
-                    scaleY = baseScale
                     translationX = driftX
                     translationY = driftY
                 },
-                contentScale = ContentScale.Fit
+                contentScale = ContentScale.Crop
             )
         }
 

--- a/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
@@ -6,6 +6,11 @@ import android.os.Build
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -15,9 +20,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -30,7 +37,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.em
+import androidx.compose.ui.graphics.CompositingStrategy
 import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
@@ -71,6 +82,7 @@ fun CitySheet(
         label = "glassColor"
     )
 
+    val shape = RoundedCornerShape((32f * s).dp)
     Box(
         modifier
             .fillMaxSize()
@@ -79,68 +91,85 @@ fun CitySheet(
                 vertical = (28f * sy).dp
             )
             .padding((28f * sx).dp, (28f * sy).dp)
-            .clip(RoundedCornerShape((32f * s).dp))
-            .background(backgroundColor)
-            .backdropBlur(8.dp)
     ) {
-        val chipSize = ((36f * s).coerceIn(24f, 36f)).sp
-
         Box(
             Modifier
-                .padding(horizontal = (56f * sx).dp, vertical = (64f * sy).dp)
-                .height((64f * s).dp)
-                .fillMaxWidth()
-                .border(
-                    width = 3.dp,
-                    color = Tokens.Colors.chipStroke,
-                    shape = RoundedCornerShape((24f * s).dp)
-                )
-                .pointerInput(Unit) { detectTapGestures { onCityChipTap() } },
-            contentAlignment = Alignment.Center
+                .matchParentSize()
+                .clip(shape)
+                .graphicsLayer { compositingStrategy = CompositingStrategy.ModulateAlpha }
         ) {
-            BasicText(
-                city,
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    fontFamily = AbysFonts.inter,
-                    fontSize   = chipSize,
-                    fontStyle  = FontStyle.Italic,
-                    fontWeight = FontWeight.Bold,
-                    color      = Tokens.Colors.text,
-                    shadow     = Shadow(
-                        Tokens.Colors.tickDark.copy(alpha = 0.35f),
-                        offset = Offset(0f, 2f),
-                        blurRadius = 4f
-                    )
-                ),
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                modifier = Modifier.padding(horizontal = 12.dp)
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .clip(shape)
+                    .backdropBlur(8.dp)
+                    .background(backgroundColor)
             )
-        }
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .clip(shape)
+            ) {
+                val chipSize = ((36f * s).coerceIn(24f, 36f)).sp
 
-        AnimatedContent(
-            targetState = pickerVisible,
-            transitionSpec = { fadeIn(tween(220)) with fadeOut(tween(180)) }
-        ) { showPicker ->
-            if (showPicker) {
-                CityPickerWheel(
-                    cities      = cities,
-                    currentCity = city,
-                    onChosen    = onCityChosen,
-                    modifier    = Modifier.fillMaxSize()
-                )
-            } else {
-                HadithFrame(
-                    text = hadith,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(
-                            start  = (100f * sx).dp,
-                            end    = (100f * sx).dp,
-                            top    = (292f * sy).dp,
-                            bottom = (120f * sy).dp
+                Box(
+                    Modifier
+                        .padding(horizontal = (56f * sx).dp, vertical = (64f * sy).dp)
+                        .height((64f * s).dp)
+                        .fillMaxWidth()
+                        .border(
+                            width = 3.dp,
+                            color = Tokens.Colors.chipStroke,
+                            shape = RoundedCornerShape((24f * s).dp)
                         )
-                )
+                        .pointerInput(Unit) { detectTapGestures { onCityChipTap() } },
+                    contentAlignment = Alignment.Center
+                ) {
+                    BasicText(
+                        city,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontFamily = AbysFonts.inter,
+                            fontSize   = chipSize,
+                            fontStyle  = FontStyle.Italic,
+                            fontWeight = FontWeight.Bold,
+                            color      = Tokens.Colors.text,
+                            shadow     = Shadow(
+                                Tokens.Colors.tickDark.copy(alpha = 0.35f),
+                                offset = Offset(0f, 2f),
+                                blurRadius = 4f
+                            )
+                        ),
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        modifier = Modifier.padding(horizontal = 12.dp)
+                    )
+                }
+
+                AnimatedContent(
+                    targetState = pickerVisible,
+                    transitionSpec = { fadeIn(tween(220)) with fadeOut(tween(180)) }
+                ) { showPicker ->
+                    if (showPicker) {
+                        CityPickerWheel(
+                            cities      = cities,
+                            currentCity = city,
+                            onChosen    = onCityChosen,
+                            modifier    = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        HadithFrame(
+                            text = hadith,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(
+                                    start  = (100f * sx).dp,
+                                    end    = (100f * sx).dp,
+                                    top    = (292f * sy).dp,
+                                    bottom = (120f * sy).dp
+                                )
+                        )
+                    }
+                }
             }
         }
     }
@@ -163,23 +192,69 @@ private fun HadithFrame(
     ) {
         val scrollState = rememberScrollState()
         Column(Modifier.verticalScroll(scrollState)) {
-            val textSize = ((26f * s).coerceIn(18f, 26f)).sp
-            BasicText(
-                text,
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    fontFamily = AbysFonts.inter,
-                    fontSize   = textSize,
-                    fontWeight = FontWeight.Bold,
-                    color      = Tokens.Colors.text,
-                    lineHeight = 1.42.em,
-                    textAlign = TextAlign.Start,
-                    shadow     = Shadow(
-                        Tokens.Colors.tickDark.copy(alpha = 0.35f),
-                        offset = Offset(0f, 2f),
-                        blurRadius = 6f
+            if (text.isBlank()) {
+                HadithPlaceholder()
+            } else {
+                val textSize = ((26f * s).coerceIn(18f, 26f)).sp
+                BasicText(
+                    text,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontFamily = AbysFonts.inter,
+                        fontSize   = textSize,
+                        fontWeight = FontWeight.Bold,
+                        color      = Tokens.Colors.text,
+                        lineHeight = 1.42.em,
+                        textAlign = TextAlign.Start,
+                        shadow     = Shadow(
+                            Tokens.Colors.tickDark.copy(alpha = 0.35f),
+                            offset = Offset(0f, 2f),
+                            blurRadius = 6f
+                        )
                     )
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HadithPlaceholder(modifier: Modifier = Modifier) {
+    val sy = Dimens.sy()
+    val s = Dimens.s()
+    val transition = rememberInfiniteTransition(label = "hadith-shimmer")
+    val shimmerShift by transition.animateFloat(
+        initialValue = -200f,
+        targetValue = 600f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1400, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "hadith-shift"
+    )
+
+    val base = Tokens.Colors.tickDark.copy(alpha = 0.18f)
+    val highlight = Color.White.copy(alpha = 0.35f)
+    val brush = Brush.linearGradient(
+        colors = listOf(base, highlight, base),
+        start = Offset(shimmerShift, 0f),
+        end = Offset(shimmerShift + 200f, 0f)
+    )
+
+    val lineHeights = listOf(28f, 28f, 28f, 24f)
+    val widths = listOf(1f, 0.92f, 0.78f, 0.64f)
+
+    Column(modifier) {
+        lineHeights.zip(widths).forEachIndexed { index, (heightPx, widthFraction) ->
+            Box(
+                Modifier
+                    .fillMaxWidth(widthFraction)
+                    .height((heightPx * sy).dp)
+                    .clip(RoundedCornerShape((14f * s).dp))
+                    .background(brush)
             )
+            if (index != lineHeights.lastIndex) {
+                Spacer(Modifier.height((18f * sy).dp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
@@ -43,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -352,43 +354,56 @@ private fun HeaderPill(
     val sy = Dimens.sy()
     val horizontalPadding = Dimens.scaledX(R.dimen.abys_pill_pad_h)
     val verticalPadding = Dimens.scaledY(R.dimen.abys_pill_pad_v)
+    val shape = RoundedCornerShape(Tokens.Radii.pill())
     Box(
         modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(Tokens.Radii.pill()))
-            .background(Tokens.Colors.overlayTop)
-            .backdropBlur(6.dp)
-            .clickable(onClick = onTap)
-            .padding(
-                horizontal = horizontalPadding,
-                vertical = verticalPadding
-            ),
-        contentAlignment = Alignment.CenterStart
+            .clip(shape)
+            .graphicsLayer { compositingStrategy = CompositingStrategy.ModulateAlpha }
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+        Box(
+            Modifier
+                .matchParentSize()
+                .clip(shape)
+                .backdropBlur(6.dp)
+                .background(Tokens.Colors.overlayTop)
+        )
+        Box(
+            Modifier
+                .matchParentSize()
+                .clip(shape)
+                .clickable(onClick = onTap)
+                .padding(
+                    horizontal = horizontalPadding,
+                    vertical = verticalPadding
+                ),
+            contentAlignment = Alignment.CenterStart
         ) {
-            Text(
-                text = city,
-                fontSize = Tokens.TypographySp.city,
-                fontWeight = FontWeight.SemiBold,
-                fontStyle = FontStyle.Italic,
-                color = Tokens.Colors.text,
-                textDecoration = TextDecoration.Underline,
-                maxLines = 1,
-                modifier = Modifier.weight(1f)
-            )
-            Text(
-                text = now,
-                fontSize = Tokens.TypographySp.timeNow,
-                fontWeight = FontWeight.Bold,
-                color = Tokens.Colors.text,
-                textAlign = TextAlign.Right,
-                maxLines = 1,
-                modifier = Modifier.wrapContentWidth(Alignment.End)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = city,
+                    fontSize = Tokens.TypographySp.city,
+                    fontWeight = FontWeight.SemiBold,
+                    fontStyle = FontStyle.Italic,
+                    color = Tokens.Colors.text,
+                    textDecoration = TextDecoration.Underline,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = now,
+                    fontSize = Tokens.TypographySp.timeNow,
+                    fontWeight = FontWeight.Bold,
+                    color = Tokens.Colors.text,
+                    textAlign = TextAlign.Right,
+                    maxLines = 1,
+                    modifier = Modifier.wrapContentWidth(Alignment.End)
+                )
+            }
         }
     }
 }
@@ -409,56 +424,69 @@ private fun PrayerCard(
     val rowSpacing = (rowStep - labelHeight).coerceAtLeast(0.dp)
     val subSpacing = (rowStep - subLabelHeight).coerceAtLeast(0.dp)
 
-    Column(
+    val shape = RoundedCornerShape(Tokens.Radii.card())
+    Box(
         modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(Tokens.Radii.card()))
-            .background(Tokens.Colors.overlayCard)
-            .backdropBlur(6.dp)
-            .padding(
-                start = Dimens.scaledX(R.dimen.abys_card_pad_h),
-                end = Dimens.scaledX(R.dimen.abys_card_pad_h),
-                top = Dimens.scaledY(R.dimen.abys_card_pad_top),
-                bottom = Dimens.scaledY(R.dimen.abys_card_pad_bottom)
-            )
+            .clip(shape)
+            .graphicsLayer { compositingStrategy = CompositingStrategy.ModulateAlpha }
     ) {
-        RowItem("Фаджр", times["Fajr"] ?: "--:--")
-        Spacer(Modifier.height(rowSpacing))
-        RowItem("Восход", times["Sunrise"] ?: "--:--")
-        Spacer(Modifier.height(rowSpacing))
-        RowItem("Зухр", times["Dhuhr"] ?: "--:--")
-        Spacer(Modifier.height(rowSpacing))
-
-        Text(
-            text = "Аср:",
-            fontSize = Tokens.TypographySp.label,
-            fontWeight = FontWeight.Bold,
-            color = Tokens.Colors.text
+        Box(
+            Modifier
+                .matchParentSize()
+                .clip(shape)
+                .backdropBlur(6.dp)
+                .background(Tokens.Colors.overlayCard)
         )
-        Spacer(Modifier.height((4f * sy).dp))
-        AsrSub(
-            label = "стандарт",
-            value = times["AsrStd"] ?: "--:--",
-            indicatorWidth = (64f * sx).dp,
-            indicatorHeight = (4f * sy).dp,
-            indicatorRadius = (2f * s).dp
-        )
-        Spacer(Modifier.height(subSpacing))
-        AsrSub(
-            label = "Ханафи",
-            value = times["AsrHana"] ?: "--:--",
-            indicatorWidth = (64f * sx).dp,
-            indicatorHeight = (4f * sy).dp,
-            indicatorRadius = (2f * s).dp
-        )
-        Spacer(Modifier.height(rowSpacing))
+        Column(
+            Modifier
+                .matchParentSize()
+                .clip(shape)
+                .padding(
+                    start = Dimens.scaledX(R.dimen.abys_card_pad_h),
+                    end = Dimens.scaledX(R.dimen.abys_card_pad_h),
+                    top = Dimens.scaledY(R.dimen.abys_card_pad_top),
+                    bottom = Dimens.scaledY(R.dimen.abys_card_pad_bottom)
+                )
+        ) {
+            RowItem("Фаджр", times["Fajr"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
+            RowItem("Восход", times["Sunrise"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
+            RowItem("Зухр", times["Dhuhr"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
 
-        RowItem("Магриб", times["Maghrib"] ?: "--:--")
-        Spacer(Modifier.height(rowSpacing))
-        RowItem("Иша", times["Isha"] ?: "--:--")
+            Text(
+                text = "Аср:",
+                fontSize = Tokens.TypographySp.label,
+                fontWeight = FontWeight.Bold,
+                color = Tokens.Colors.text
+            )
+            Spacer(Modifier.height((4f * sy).dp))
+            AsrSub(
+                label = "стандарт",
+                value = times["AsrStd"] ?: "--:--",
+                indicatorWidth = (64f * sx).dp,
+                indicatorHeight = (4f * sy).dp,
+                indicatorRadius = (2f * s).dp
+            )
+            Spacer(Modifier.height(subSpacing))
+            AsrSub(
+                label = "Ханафи",
+                value = times["AsrHana"] ?: "--:--",
+                indicatorWidth = (64f * sx).dp,
+                indicatorHeight = (4f * sy).dp,
+                indicatorRadius = (2f * s).dp
+            )
+            Spacer(Modifier.height(rowSpacing))
 
-        Spacer(Modifier.height((24f * sy).dp))
-        Timeline(thirds)
+            RowItem("Магриб", times["Maghrib"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
+            RowItem("Иша", times["Isha"] ?: "--:--")
+
+            Spacer(Modifier.height((24f * sy).dp))
+            Timeline(thirds)
+        }
     }
 }
 

--- a/app/src/main/res/values/tokens_colors.xml
+++ b/app/src/main/res/values/tokens_colors.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Альфы в ARGB (#AARRGGBB) -->
     <color name="abys_fg">#FFFFFFFF</color>
-    <color name="abys_overlayTop">#73000000</color>
-    <color name="abys_overlayCard">#59000000</color>
+    <color name="abys_overlayTop">#42000000</color>
+    <color name="abys_overlayCard">#42000000</color>
     <color name="abys_tickFull">#FFFFFFFF</color>
     <color name="abys_separator50">#80FFFFFF</color>
     <color name="abys_chipStroke">#5CFFFFFF</color>


### PR DESCRIPTION
## Summary
- soften the glass overlays and split blur layers from foreground content on the dashboard cards
- redesign the city sheet background and hadith view with dedicated blur shells and a shimmer placeholder
- rework the effect carousel into an infinite loop with stronger fling inertia and update the city picker wheel snapping
- seed the view model and repository with cached prayer data so the UI stays populated until network loads

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1719fb20c832d8ee927bb0dd4c41d