### PR TITLE
Fix Inter font XML queries

### DIFF
--- a/app/src/main/res/font/inter_bold.xml
+++ b/app/src/main/res/font/inter_bold.xml
@@ -6,6 +6,6 @@
         android:fontWeight="700"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=700"
+        app:fontProviderQuery="name=Inter&amp;weight=700"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>

--- a/app/src/main/res/font/inter_bold_italic.xml
+++ b/app/src/main/res/font/inter_bold_italic.xml
@@ -6,6 +6,6 @@
         android:fontWeight="700"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=700&italic=1"
+        app:fontProviderQuery="name=Inter&amp;weight=700&amp;italic=1"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>

--- a/app/src/main/res/font/inter_family.xml
+++ b/app/src/main/res/font/inter_family.xml
@@ -6,34 +6,34 @@
         android:fontWeight="400"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=400"
+        app:fontProviderQuery="name=Inter&amp;weight=400"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
     <font
         android:fontStyle="normal"
         android:fontWeight="600"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=600"
+        app:fontProviderQuery="name=Inter&amp;weight=600"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
     <font
         android:fontStyle="normal"
         android:fontWeight="700"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=700"
+        app:fontProviderQuery="name=Inter&amp;weight=700"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
     <font
         android:fontStyle="italic"
         android:fontWeight="400"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=400&italic=1"
+        app:fontProviderQuery="name=Inter&amp;weight=400&amp;italic=1"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
     <font
         android:fontStyle="italic"
         android:fontWeight="700"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=700&italic=1"
+        app:fontProviderQuery="name=Inter&amp;weight=700&amp;italic=1"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>

--- a/app/src/main/res/font/inter_italic.xml
+++ b/app/src/main/res/font/inter_italic.xml
@@ -6,6 +6,6 @@
         android:fontWeight="400"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=400&italic=1"
+        app:fontProviderQuery="name=Inter&amp;weight=400&amp;italic=1"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>

--- a/app/src/main/res/font/inter_regular.xml
+++ b/app/src/main/res/font/inter_regular.xml
@@ -6,6 +6,6 @@
         android:fontWeight="400"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=400"
+        app:fontProviderQuery="name=Inter&amp;weight=400"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>

--- a/app/src/main/res/font/inter_semibold.xml
+++ b/app/src/main/res/font/inter_semibold.xml
@@ -6,6 +6,6 @@
         android:fontWeight="600"
         app:fontProviderAuthority="com.google.android.gms.fonts"
         app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="name=Inter&weight=600"
+        app:fontProviderQuery="name=Inter&amp;weight=600"
         app:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />
 </font-family>


### PR DESCRIPTION
## Summary
- escape ampersands in the Inter font provider queries to produce valid XML

## Testing
- ./gradlew :app:mergeDebugResources --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f178169944832d9f3a0036aa56c343