### PR TITLE
Fix snapping behavior to match Compose 1.6 APIs

### DIFF
--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -1,7 +1,6 @@
 package com.example.abys.ui
 
 import androidx.annotation.DrawableRes
-import androidx.compose.animation.core.rememberSplineBasedDecay
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
@@ -80,10 +79,8 @@ fun EffectCarousel(
     var hasAligned by remember { mutableStateOf(false) }
     LaunchedEffect(items) { hasAligned = false }
 
-    val decay = rememberSplineBasedDecay<Float>(frictionMultiplier = 0.72f)
     val flingBehavior = rememberSnapFlingBehavior(
-        lazyListState = listState,
-        decayAnimationSpec = decay
+        lazyListState = listState
     )
     val scope = rememberCoroutineScope()
 

--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -1,6 +1,5 @@
 package com.example.abys.ui.screen
 
-import androidx.compose.animation.core.rememberSplineBasedDecay
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -73,8 +72,7 @@ fun CityPickerWheel(
     LaunchedEffect(cities) { hasAligned = false }
 
     val flingBehavior = rememberSnapFlingBehavior(
-        lazyListState = listState,
-        decayAnimationSpec = rememberSplineBasedDecay<Float>(frictionMultiplier = 0.78f)
+        lazyListState = listState
     )
 
     LaunchedEffect(cities, currentCity) {


### PR DESCRIPTION
## Summary
- remove usages of rememberSplineBasedDecay that require newer compose artifacts
- rely on the default rememberSnapFlingBehavior for the carousel and city picker lists to keep builds green

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f17a5fb42c832da9299959d6025f4a