### PR TITLE
Restore matchParentSize modifier extension

### DIFF
--- a/app/src/main/java/androidx/compose/foundation/layout/MatchParentSize.kt
+++ b/app/src/main/java/androidx/compose/foundation/layout/MatchParentSize.kt
@@ -1,0 +1,55 @@
+package androidx.compose.foundation.layout
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+
+/**
+ * Replacement for the removed [Modifier.matchParentSize] extension from older Compose versions.
+ */
+@Stable
+fun Modifier.matchParentSize(): Modifier = this.then(MatchParentSizeModifier)
+
+private object MatchParentSizeModifier : LayoutModifier {
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val width = constraints.maxWidth
+        val height = constraints.maxHeight
+
+        val placeable = measurable.measure(
+            Constraints.fixed(width, height)
+        )
+
+        return layout(width, height) {
+            placeable.placeRelative(0, 0)
+        }
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int
+    ) = measurable.minIntrinsicHeight(width)
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ) = measurable.minIntrinsicWidth(height)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int
+    ) = measurable.maxIntrinsicHeight(width)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ) = measurable.maxIntrinsicWidth(height)
+}


### PR DESCRIPTION
## Summary
- recreate a local Modifier.matchParentSize extension to unblock references in CitySheet and MainScreen

## Testing
- Not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f17bfd60e0832d8b2df38f17b2aea6