### PR TITLE
Fix slideshow gradient configuration

### DIFF
--- a/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
+++ b/app/src/main/java/com/example/abys/ui/background/SlideshowBackground.kt
@@ -102,7 +102,6 @@ fun SlideshowBackground(
     val topAlpha = lerp(0.08f, 0.1f, progress)
     val bottomAlpha = lerp(0.12f, 0.12f, 1f - abs(progress - 0.5f) * 2f)
     val gradientStops = arrayOf(
-    val gradientStops = listOf(
         0f to Color.Black.copy(alpha = topAlpha),
         0.22f to Color.Transparent,
         0.78f to Color.Transparent,
@@ -159,8 +158,6 @@ fun SlideshowBackground(
             Modifier
                 .fillMaxSize()
                 .background(brush = Brush.verticalGradient(*gradientStops))
-                .background(brush = Brush.verticalGradient(colorStops = gradientStops))
-                .background(Brush.verticalGradient(gradientStops))
         )
     }
 }


### PR DESCRIPTION
## Summary
- fix the slideshow gradient stop initialization so it spreads correctly
- remove duplicate gradient background calls in the slideshow background composable

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1a486f2a8832d99c609dae25dafc0