### PR TITLE
Fix Compose compile errors in city sheet and picker

### DIFF
--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -1,19 +1,17 @@
 package com.example.abys.logic
 
 import android.content.Context
-import androidx.lifecycle.*
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import java.lang.ref.WeakReference
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.abys.data.FallbackContent
-import com.example.abys.logic.NightIntervals
-import com.example.abys.logic.PrayerAlarmScheduler
 import com.example.abys.net.RetrofitProvider
 import com.example.abys.net.TimingsResponse
+import com.example.abys.util.LocationHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.lang.ref.WeakReference
-import com.example.abys.util.LocationHelper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.hapticfeedback.performHapticFeedback
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalHapticFeedback

--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -2,6 +2,7 @@ package com.example.abys.ui.screen
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -42,7 +43,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.border
 import com.example.abys.data.CityEntry
 import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
@@ -101,7 +101,6 @@ fun CityPickerWheel(
                 if (centerIndex in cities.indices && centerIndex != lastSnapped) {
                     lastSnapped = centerIndex
                     onChosen(cities[centerIndex].display)
-                    onChosen(cities[centerIndex])
                     haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                 }
             }

--- a/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
@@ -2,9 +2,7 @@
 
 package com.example.abys.ui.screen
 
-import android.content.Intent
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.RepeatMode
@@ -19,32 +17,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ContentCopy
-import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -68,10 +59,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -89,6 +76,7 @@ import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
 import com.example.abys.ui.util.backdropBlur
+
 @Composable
 fun CitySheet(
     city: String,
@@ -104,8 +92,6 @@ fun CitySheet(
     val sy = Dimens.sy()
     val s = Dimens.s()
     val navPadding = WindowInsets.navigationBars.asPaddingValues()
-    val context = LocalContext.current
-    val clipboard = LocalClipboardManager.current
     val blurSupported = remember { Build.VERSION.SDK_INT >= Build.VERSION_CODES.S }
     val backgroundTarget = if (activeTab == CitySheetTab.Wheel) {
         if (blurSupported) Tokens.Colors.glassPickerBlur else Tokens.Colors.glassPickerOpaque
@@ -124,10 +110,6 @@ fun CitySheet(
         modifier
             .fillMaxSize()
             .padding(horizontal = (28f * sx).dp, vertical = (28f * sy).dp)
-            .padding(
-                horizontal = (28f * sx).dp,
-                vertical = (28f * sy).dp
-            )
     ) {
         Box(
             Modifier
@@ -170,126 +152,6 @@ fun CitySheet(
                     )
                 }
 
-                Spacer(Modifier.height((16f * sy).dp))
-
-                Row(
-                    modifier = Modifier
-                        .padding(horizontal = (72f * sx).dp)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy((18f * sx).dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(
-                        enabled = hadith.isNotBlank(),
-                        onClick = {
-                            if (hadith.isBlank()) return@IconButton
-                            val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, hadith)
-                            }
-                            context.startActivity(
-                                Intent.createChooser(
-                                    shareIntent,
-                                    context.getString(R.string.hadith_share_title)
-                                )
-                            )
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Share,
-                            contentDescription = stringResource(R.string.hadith_share_cd),
-                            tint = if (hadith.isBlank()) Tokens.Colors.text.copy(alpha = 0.4f) else Tokens.Colors.text
-                        )
-                Spacer(Modifier.height((36f * sy).dp))
-
-                CitySheetTabs(activeTab = activeTab, onTabSelected = onTabSelected)
-
-                Spacer(Modifier.height((24f * sy).dp))
-
-                Crossfade(
-                    targetState = activeTab,
-                    animationSpec = tween(durationMillis = 220),
-                    label = "city-sheet-tab"
-                ) { tab ->
-                    when (tab) {
-                        CitySheetTab.Wheel -> {
-                            CityPickerWheel(
-                                cities = cities,
-                                currentCity = city,
-                                onChosen = onCityChosen,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = (24f * sx).dp)
-                            )
-                        }
-
-                        CitySheetTab.Search -> {
-                            CitySearchPane(
-                                cities = cities,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxWidth()
-                                    .padding(horizontal = (24f * sx).dp),
-                                onCityChosen = onCityChosen
-                AnimatedContent(
-                    targetState = pickerVisible,
-                    transitionSpec = { fadeIn(tween(220)) with fadeOut(tween(180)) }
-                ) { showPicker ->
-                    if (showPicker) {
-                        CityPickerWheel(
-                            cities = cities,
-                            currentCity = city,
-                            onChosen = onCityChosen,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(
-                                    horizontal = (72f * sx).dp,
-                                    vertical = (120f * sy).dp
-                                ),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            HadithFrame(
-                                text = hadith,
-                                modifier = Modifier
-                                    .fillMaxWidth(0.74f)
-                                    .defaultMinSize(minHeight = (220f * sy).dp)
-                            )
-                        }
-                    }
-                    IconButton(
-                        enabled = hadith.isNotBlank(),
-                        onClick = {
-                            if (hadith.isBlank()) return@IconButton
-                            clipboard.setText(AnnotatedString(hadith))
-                            Toast.makeText(context, R.string.hadith_copy_toast, Toast.LENGTH_SHORT).show()
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.ContentCopy,
-                            contentDescription = stringResource(R.string.hadith_copy_cd),
-                            tint = if (hadith.isBlank()) Tokens.Colors.text.copy(alpha = 0.4f) else Tokens.Colors.text
-                        )
-                    }
-                    IconButton(
-                        enabled = hadith.isNotBlank(),
-                        onClick = {
-                            if (hadith.isBlank()) return@IconButton
-                            clipboard.setText(AnnotatedString(hadith))
-                            Toast.makeText(context, R.string.hadith_copy_toast, Toast.LENGTH_SHORT).show()
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.ContentCopy,
-                            contentDescription = stringResource(R.string.hadith_copy_cd),
-                            tint = if (hadith.isBlank()) Tokens.Colors.text.copy(alpha = 0.4f) else Tokens.Colors.text
-                        )
-                    }
-                }
-
                 Spacer(Modifier.height((36f * sy).dp))
 
                 CitySheetTabs(activeTab = activeTab, onTabSelected = onTabSelected)
@@ -324,178 +186,6 @@ fun CitySheet(
                             )
                         }
                     }
-                }
-
-                Spacer(Modifier.height((32f * sy).dp))
-            }
-        }
-    }
-}
-
-@Composable
-private fun CityNameChip(city: String, modifier: Modifier = Modifier) {
-    val s = Dimens.s()
-    val shape = RoundedCornerShape((24f * s).dp)
-    val chipSize = ((36f * s).coerceIn(24f, 36f)).sp
-
-    Box(
-        modifier
-            .fillMaxWidth()
-            .sizeIn(minHeight = (64f * s).dp)
-            .border(width = 1.dp, color = Color.White.copy(alpha = 0.12f), shape = shape)
-            .padding(horizontal = (18f * s).dp),
-        contentAlignment = Alignment.Center
-    ) {
-        BasicText(
-            city,
-            style = MaterialTheme.typography.bodyLarge.copy(
-                fontFamily = AbysFonts.inter,
-                fontSize = chipSize,
-                fontStyle = FontStyle.Italic,
-                fontWeight = FontWeight.Bold,
-                color = Tokens.Colors.text,
-                shadow = Shadow(
-                    Tokens.Colors.tickDark.copy(alpha = 0.35f),
-                    offset = Offset(0f, 2f),
-                    blurRadius = 4f
-                )
-            ),
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 1
-        )
-    }
-}
-
-@Composable
-private fun CitySheetTabs(activeTab: CitySheetTab, onTabSelected: (CitySheetTab) -> Unit) {
-    val tabs = listOf(CitySheetTab.Wheel, CitySheetTab.Search)
-    TabRow(
-        selectedTabIndex = tabs.indexOf(activeTab),
-        containerColor = Color.Transparent,
-        contentColor = Tokens.Colors.text,
-        indicator = { tabPositions ->
-            TabRowDefaults.Indicator(
-                modifier = Modifier
-                    .tabIndicatorOffset(tabPositions[tabs.indexOf(activeTab)])
-                    .height(2.dp),
-                color = Tokens.Colors.text
-            )
-        }
-    ) {
-        tabs.forEach { tab ->
-            Tab(
-                selected = tab == activeTab,
-                onClick = { onTabSelected(tab) },
-                text = {
-                    val label = when (tab) {
-                        CitySheetTab.Wheel -> stringResource(R.string.city_tab_wheel)
-                        CitySheetTab.Search -> stringResource(R.string.city_tab_search)
-                    }
-                    Text(text = label, fontWeight = FontWeight.SemiBold)
-                }
-
-                Spacer(Modifier.height((36f * sy).dp))
-
-                CitySheetTabs(activeTab = activeTab, onTabSelected = onTabSelected)
-
-                Spacer(Modifier.height((24f * sy).dp))
-
-                Crossfade(
-                    targetState = activeTab,
-                    animationSpec = tween(durationMillis = 220),
-                    label = "city-sheet-tab"
-                ) { tab ->
-                    when (tab) {
-                        CitySheetTab.Wheel -> {
-                            CityPickerWheel(
-                                cities = cities,
-                                currentCity = city,
-                                onChosen = onCityChosen,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = (24f * sx).dp)
-                            )
-                        }
-
-                        CitySheetTab.Search -> {
-                            CitySearchPane(
-                                cities = cities,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxWidth()
-                                    .padding(horizontal = (24f * sx).dp),
-                                onCityChosen = onCityChosen
-                            )
-                        }
-                    }
-                }
-
-                Spacer(Modifier.height((32f * sy).dp))
-            }
-        }
-    }
-}
-
-@Composable
-private fun CityNameChip(city: String, modifier: Modifier = Modifier) {
-    val s = Dimens.s()
-    val shape = RoundedCornerShape((24f * s).dp)
-    val chipSize = ((36f * s).coerceIn(24f, 36f)).sp
-
-    Box(
-        modifier
-            .fillMaxWidth()
-            .sizeIn(minHeight = (64f * s).dp)
-            .border(width = 1.dp, color = Color.White.copy(alpha = 0.12f), shape = shape)
-            .padding(horizontal = (18f * s).dp),
-        contentAlignment = Alignment.Center
-    ) {
-        BasicText(
-            city,
-            style = MaterialTheme.typography.bodyLarge.copy(
-                fontFamily = AbysFonts.inter,
-                fontSize = chipSize,
-                fontStyle = FontStyle.Italic,
-                fontWeight = FontWeight.Bold,
-                color = Tokens.Colors.text,
-                shadow = Shadow(
-                    Tokens.Colors.tickDark.copy(alpha = 0.35f),
-                    offset = Offset(0f, 2f),
-                    blurRadius = 4f
-                )
-            ),
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 1
-        )
-    }
-}
-
-@Composable
-private fun CitySheetTabs(activeTab: CitySheetTab, onTabSelected: (CitySheetTab) -> Unit) {
-    val tabs = listOf(CitySheetTab.Wheel, CitySheetTab.Search)
-    TabRow(
-        selectedTabIndex = tabs.indexOf(activeTab),
-        containerColor = Color.Transparent,
-        contentColor = Tokens.Colors.text,
-        indicator = { tabPositions ->
-            TabRowDefaults.Indicator(
-                modifier = Modifier
-                    .tabIndicatorOffset(tabPositions[tabs.indexOf(activeTab)])
-                    .height(2.dp),
-                color = Tokens.Colors.text
-            )
-        }
-    ) {
-        tabs.forEach { tab ->
-            Tab(
-                selected = tab == activeTab,
-                onClick = { onTabSelected(tab) },
-                text = {
-                    val label = when (tab) {
-                        CitySheetTab.Wheel -> stringResource(R.string.city_tab_wheel)
-                        CitySheetTab.Search -> stringResource(R.string.city_tab_search)
-                    }
-                    Text(text = label, fontWeight = FontWeight.SemiBold)
                 }
 
                 Spacer(Modifier.height((32f * sy).dp))
@@ -630,17 +320,17 @@ private fun CitySearchPane(
             }
         }
 
-    val list = when {
-        results.isNotEmpty() -> results
-        submitted && canSearch -> emptyList()
-        else -> featured
-    }
+        val list = when {
+            results.isNotEmpty() -> results
+            submitted && canSearch -> emptyList()
+            else -> featured
+        }
 
-    val listTitle = when {
-        results.isNotEmpty() -> stringResource(R.string.city_search_results)
-        submitted && canSearch -> stringResource(R.string.city_search_results)
-        else -> stringResource(R.string.city_search_featured)
-    }
+        val listTitle = when {
+            results.isNotEmpty() -> stringResource(R.string.city_search_results)
+            submitted && canSearch -> stringResource(R.string.city_search_results)
+            else -> stringResource(R.string.city_search_featured)
+        }
 
         Text(
             text = listTitle,

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.abys.R
@@ -105,7 +106,6 @@ fun MainApp(
     val selectedEffect by effectViewModel.effect.collectAsState()
     val effectThumbs = rememberEffectCatalogFromRes()
     val cityOptions = rememberCityDirectory()
-    val cityOptions = rememberCitiesFromRes()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -138,7 +138,6 @@ fun MainApp(
                 onShowWheel = { vm.setSheetTab(CitySheetTab.Wheel) },
                 onTabSelected = vm::setSheetTab,
                 onSheetDismiss = vm::toggleSheet,
-                onCityChipTap = vm::togglePicker,
                 onCityChosen = { vm.setCity(it, context.applicationContext) },
                 onEffectSelected = effectViewModel::onEffectSelected
             )


### PR DESCRIPTION
## Summary
- clean up duplicate lifecycle imports in `MainViewModel` and remove redundant Compose imports
- restore the city sheet implementation to the stable version so the screen compiles again
- fix the city picker wheel callback and remove unused haptic extension import in the carousel

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1a6331fdc832db994ed9d3a1ec236