### PR TITLE
Fix Compose lint warnings in MainScreen

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -116,24 +116,28 @@ private object GlassDefaults {
 
 // Единая шкала таймингов — чтобы анимации были согласованы
 private object Dur {
-    const val XShort = 180
-    const val Short = 200
-    const val Base = 220
-    const val Med = 240
-    const val Long = 260
+    const val X_SHORT = 180
+    const val SHORT = 200
+    const val BASE = 220
+    const val MED = 240
+    const val LONG = 260
 }
 
 // Палитра и типографика под «серый» макет
 private object TypeTone {
-    val primary = Tokens.Colors.text.copy(alpha = 0.92f)
-    val secondary = Tokens.Colors.text.copy(alpha = 0.78f)
-    val dim = Tokens.Colors.text.copy(alpha = 0.62f)
-    val divider = Color.White.copy(alpha = 0.08f)
+    val primary: Color
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.92f)
+    val secondary: Color
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.78f)
+    val dim: Color
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.62f)
+    val divider: Color
+        @Composable get() = Color.White.copy(alpha = 0.08f)
 }
 
 @Composable
 private fun ThinDivider(modifier: Modifier = Modifier) {
-    Divider(modifier = modifier, color = TypeTone.divider, thickness = 1.dp)
+    HorizontalDivider(modifier = modifier, color = TypeTone.divider, thickness = 1.dp)
 }
 
 @Composable
@@ -141,7 +145,7 @@ private fun MutedBackgroundCrossfade(effect: EffectId) {
     Crossfade(
         modifier = Modifier.fillMaxSize(),
         targetState = effect,
-        animationSpec = tween(durationMillis = Dur.XShort),
+        animationSpec = tween(durationMillis = Dur.X_SHORT),
         label = "muted-effect-background"
     ) { target ->
         Box(Modifier.fillMaxSize()) {
@@ -260,55 +264,55 @@ fun MainScreen(
     val headerLift = remember(density, sy) { with(density) { (14f * sy).dp.toPx() } }
 
     val prayerAlpha by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = if (targetState == SurfaceStage.Dashboard) Dur.Short else Dur.Med) },
+        transitionSpec = { tween(durationMillis = if (targetState == SurfaceStage.Dashboard) Dur.SHORT else Dur.MED) },
         label = "prayerAlpha"
     ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0f }
     val prayerScale by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Long) },
+        transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "prayerScale"
     ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.94f }
     val prayerTranslation by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Med) },
+        transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "prayerTranslation"
     ) { st -> if (st == SurfaceStage.Dashboard) 0f else -cardLift }
 
     val headerAlpha by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Base) },
+        transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "headerAlpha"
     ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.82f }
     val headerTranslation by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Base) },
+        transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "headerTranslation"
     ) { st -> if (st == SurfaceStage.Dashboard) 0f else -headerLift }
 
     val carouselAlpha by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Base) },
+        transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "carouselAlpha"
     ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.45f }
     val carouselScale by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Med) },
+        transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "carouselScale"
     ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.92f }
     val carouselTranslation by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Med) },
+        transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "carouselTranslation"
     ) { st -> if (st == SurfaceStage.Dashboard) 0f else carouselDrop }
 
     val scrimAlpha by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Base) },
+        transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "scrimAlpha"
     ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
 
     val sheetAlpha by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Med) },
+        transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "sheetAlpha"
     ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
     val sheetTranslationX by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Long) },
+        transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetTranslationX"
     ) { st -> if (st == SurfaceStage.Dashboard) sheetHiddenOffset else 0f }
     val sheetTranslationY by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Long) },
+        transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetTranslationY"
     ) { st ->
         when (st) {
@@ -318,7 +322,7 @@ fun MainScreen(
         }
     }
     val sheetScale by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = Dur.Long) },
+        transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetScale"
     ) { st ->
         when (st) {
@@ -383,8 +387,8 @@ fun MainScreen(
         if (prayerAlpha > 0.01f) {
             AnimatedVisibility(
                 visible = !showSheet,
-                enter = fadeIn(tween(Dur.Base)) + scaleIn(initialScale = 0.96f, animationSpec = tween(Dur.Base)),
-                exit = fadeOut(tween(Dur.XShort)) + scaleOut(targetScale = 0.96f, animationSpec = tween(Dur.XShort))
+                enter = fadeIn(tween(Dur.BASE)) + scaleIn(initialScale = 0.96f, animationSpec = tween(Dur.BASE)),
+                exit = fadeOut(tween(Dur.X_SHORT)) + scaleOut(targetScale = 0.96f, animationSpec = tween(Dur.X_SHORT))
             ) {
                 PrayerCard(
                     times = prayerTimes,
@@ -438,10 +442,10 @@ fun MainScreen(
         if (sheetAlpha > 0.01f) {
             AnimatedVisibility(
                 visible = showSheet,
-                enter = fadeIn(tween(Dur.Base)) +
-                    slideInHorizontally(initialOffsetX = { it / 6 }, animationSpec = tween(Dur.Base)),
-                exit = fadeOut(tween(Dur.XShort)) +
-                    slideOutHorizontally(targetOffsetX = { it / 6 }, animationSpec = tween(Dur.XShort))
+                enter = fadeIn(tween(Dur.BASE)) +
+                    slideInHorizontally(initialOffsetX = { it / 6 }, animationSpec = tween(Dur.BASE)),
+                exit = fadeOut(tween(Dur.X_SHORT)) +
+                    slideOutHorizontally(targetOffsetX = { it / 6 }, animationSpec = tween(Dur.X_SHORT))
             ) {
                 GlassSheetContainer(
                     modifier = Modifier
@@ -479,7 +483,6 @@ private fun HeaderPill(
     modifier: Modifier = Modifier,
     onTap: () -> Unit
 ) {
-    val sx = Dimens.sx()
     val sy = Dimens.sy()
     val horizontalPadding = Dimens.scaledX(R.dimen.abys_pill_pad_h)
     val verticalPadding = Dimens.scaledY(R.dimen.abys_pill_pad_v)
@@ -560,7 +563,7 @@ private fun PrayerCard(
     var thirdsExpanded by rememberSaveable { mutableStateOf(true) }
     val rotation by animateFloatAsState(
         targetValue = if (thirdsExpanded) 180f else 0f,
-        animationSpec = tween(durationMillis = Dur.Short),
+        animationSpec = tween(durationMillis = Dur.SHORT),
         label = "night-toggle"
     )
 
@@ -589,7 +592,7 @@ private fun PrayerCard(
                     top = Dimens.scaledY(R.dimen.abys_card_pad_top),
                     bottom = Dimens.scaledY(R.dimen.abys_card_pad_bottom)
                 )
-                .animateContentSize(animationSpec = tween(Dur.Base))
+                .animateContentSize(animationSpec = tween(Dur.BASE))
         ) {
             RowItem("Фаджр", times["Fajr"] ?: "--:--")
             ThinDivider(Modifier.padding(vertical = (6f * sy).dp))
@@ -655,8 +658,8 @@ private fun PrayerCard(
             }
             AnimatedVisibility(
                 visible = thirdsExpanded,
-                enter = expandVertically(animationSpec = tween(Dur.Base)) + fadeIn(tween(Dur.XShort)),
-                exit = shrinkVertically(animationSpec = tween(Dur.Base)) + fadeOut(tween(Dur.XShort))
+                enter = expandVertically(animationSpec = tween(Dur.BASE)) + fadeIn(tween(Dur.X_SHORT)),
+                exit = shrinkVertically(animationSpec = tween(Dur.BASE)) + fadeOut(tween(Dur.X_SHORT))
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Spacer(Modifier.height((16f * sy).dp))


### PR DESCRIPTION
## Summary
- convert TypeTone palette values into composable getters so they no longer trigger runtime compose access
- rename duration constants to follow Kotlin const naming guidelines and update every transition to use the new identifiers
- swap the deprecated Divider usage for HorizontalDivider and drop the unused scaling property from HeaderPill

## Testing
- ./gradlew lint *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f238a0ecbc832db4a47f6e1cfb6461