### PR TITLE
Refine prayer table layout and styling

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -35,6 +36,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -45,6 +47,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
@@ -182,11 +185,12 @@ private fun MutedBackgroundCrossfade(effect: EffectId) {
 private fun scaledSp(basePx: Int, scale: Float) = (basePx * scale).roundToInt().sp
 
 private object TypeScale {
-    val city = scaledSp(Tokens.TypographyPx.city, 0.84f)
-    val timeNow = scaledSp(Tokens.TypographyPx.timeNow, 0.84f)
-    val label = scaledSp(Tokens.TypographyPx.label, 0.76f)
-    val subLabel = scaledSp(Tokens.TypographyPx.subLabel, 0.74f)
-    val timeline = scaledSp(Tokens.TypographyPx.timeline, 0.72f)
+    val eyebrow = scaledSp(Tokens.TypographyPx.timeline, 0.6f)
+    val city = scaledSp(Tokens.TypographyPx.city, 0.76f)
+    val timeNow = scaledSp(Tokens.TypographyPx.timeNow, 0.76f)
+    val label = scaledSp(Tokens.TypographyPx.label, 0.7f)
+    val subLabel = scaledSp(Tokens.TypographyPx.subLabel, 0.68f)
+    val timeline = scaledSp(Tokens.TypographyPx.timeline, 0.66f)
 }
 
 @Composable
@@ -499,6 +503,7 @@ private fun HeaderPill(
     val sy = Dimens.sy()
     val horizontalPadding = Dimens.scaledX(R.dimen.abys_pill_pad_h)
     val verticalPadding = Dimens.scaledY(R.dimen.abys_pill_pad_v)
+    val eyebrowSpacing = (6f * sy).dp
     val shape = RoundedCornerShape(Tokens.Radii.pill())
 
     Box(
@@ -529,30 +534,41 @@ private fun HeaderPill(
                 .padding(horizontal = horizontalPadding, vertical = verticalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
-            Row(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalArrangement = Arrangement.spacedBy(eyebrowSpacing)
             ) {
                 Text(
-                    text = city,
-                    fontSize = TypeScale.city,
+                    text = "Город",
+                    fontSize = TypeScale.eyebrow,
                     fontWeight = FontWeight.Medium,
-                    color = TypeTone.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
+                    color = TypeTone.dim
                 )
-                Text(
-                    text = now,
-                    fontSize = TypeScale.timeNow,
-                    fontWeight = FontWeight.SemiBold,
-                    color = TypeTone.secondary,
-                    textAlign = TextAlign.Right,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.wrapContentWidth(Alignment.End)
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = city,
+                        fontSize = TypeScale.city,
+                        fontWeight = FontWeight.Medium,
+                        color = TypeTone.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = now,
+                        fontSize = TypeScale.timeNow,
+                        fontWeight = FontWeight.SemiBold,
+                        color = TypeTone.secondary,
+                        textAlign = TextAlign.Right,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.wrapContentWidth(Alignment.End)
+                    )
+                }
             }
         }
     }
@@ -568,11 +584,14 @@ private fun PrayerCard(
     val sy = Dimens.sy()
     val s = Dimens.s()
     val shape = RoundedCornerShape(Tokens.Radii.card())
-    val rowStep = Dimens.scaledY(R.dimen.abys_row_step)
-    val labelHeight = (Tokens.TypographyPx.label * sy).dp
-    val subLabelHeight = (Tokens.TypographyPx.subLabel * sy).dp
-    val rowSpacing = ((rowStep - labelHeight) * 0.6f).coerceAtLeast(6.dp)
-    val subSpacing = ((rowStep - subLabelHeight) * 0.6f).coerceAtLeast(4.dp)
+    val rowSpacing = (10f * sy).dp
+    val subSpacing = (6f * sy).dp
+    val dividerPadding = (5f * sy).dp
+    val blockSpacing = (18f * sy).dp
+    val togglePadding = PaddingValues(
+        vertical = (10f * sy).dp,
+        horizontal = (18f * sx).dp
+    )
     var thirdsExpanded by rememberSaveable { mutableStateOf(true) }
     val rotation by animateFloatAsState(
         targetValue = if (thirdsExpanded) 180f else 0f,
@@ -608,52 +627,61 @@ private fun PrayerCard(
                 .animateContentSize(animationSpec = tween(Dur.BASE))
         ) {
             RowItem("Фаджр", times["Fajr"] ?: "--:--")
-            ThinDivider(Modifier.padding(vertical = (6f * sy).dp))
             Spacer(Modifier.height(rowSpacing))
-            RowItem("Восход", times["Sunrise"] ?: "--:--")
-            ThinDivider(Modifier.padding(vertical = (6f * sy).dp))
-            Spacer(Modifier.height(rowSpacing))
-            RowItem("Зухр", times["Dhuhr"] ?: "--:--")
-            ThinDivider(Modifier.padding(vertical = (6f * sy).dp))
+            ThinDivider(Modifier.padding(vertical = dividerPadding))
             Spacer(Modifier.height(rowSpacing))
 
-            Text(
-                text = "Аср:",
-                fontSize = TypeScale.label,
-                fontWeight = FontWeight.SemiBold,
-                color = TypeTone.primary
-            )
-            Spacer(Modifier.height((4f * sy).dp))
+            RowItem("Восход", times["Sunrise"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
+            ThinDivider(Modifier.padding(vertical = dividerPadding))
+            Spacer(Modifier.height(rowSpacing))
+
+            RowItem("Зухр", times["Dhuhr"] ?: "--:--")
+            Spacer(Modifier.height(rowSpacing))
+            ThinDivider(Modifier.padding(vertical = dividerPadding))
+            Spacer(Modifier.height(rowSpacing))
+
+            SectionHeading("Аср")
+            Spacer(Modifier.height((2f * sy).dp))
             AsrSub(
                 label = "стандарт",
                 value = times["AsrStd"] ?: "--:--",
-                indicatorWidth = (64f * sx).dp,
+                indicatorWidth = (60f * sx).dp,
                 indicatorHeight = (4f * sy).dp,
                 indicatorRadius = (2f * s).dp,
-                spacing = (12f * sx).dp
+                spacing = (10f * sx).dp
             )
             Spacer(Modifier.height(subSpacing))
             AsrSub(
-                label = "Ханафи",
+                label = "ханафи",
                 value = times["AsrHana"] ?: "--:--",
-                indicatorWidth = (64f * sx).dp,
+                indicatorWidth = (60f * sx).dp,
                 indicatorHeight = (4f * sy).dp,
                 indicatorRadius = (2f * s).dp,
-                spacing = (12f * sx).dp
+                spacing = (10f * sx).dp
             )
-            ThinDivider(Modifier.padding(vertical = (8f * sy).dp))
+            Spacer(Modifier.height(rowSpacing))
+            ThinDivider(Modifier.padding(vertical = dividerPadding))
             Spacer(Modifier.height(rowSpacing))
 
             RowItem("Магриб", times["Maghrib"] ?: "--:--")
-            ThinDivider(Modifier.padding(vertical = (6f * sy).dp))
             Spacer(Modifier.height(rowSpacing))
+            ThinDivider(Modifier.padding(vertical = dividerPadding))
+            Spacer(Modifier.height(rowSpacing))
+
             RowItem("Иша", times["Isha"] ?: "--:--")
 
-            Spacer(Modifier.height((24f * sy).dp))
+            Spacer(Modifier.height(blockSpacing))
 
             OutlinedButton(
                 onClick = { thirdsExpanded = !thirdsExpanded },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = togglePadding,
+                border = BorderStroke(1.dp, TypeTone.divider),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    containerColor = Color.Transparent,
+                    contentColor = TypeTone.primary
+                )
             ) {
                 Text(
                     text = "Ночь (3 части)",
@@ -695,6 +723,7 @@ private fun RowItem(label: String, value: String) {
             fontSize = TypeScale.label,
             fontWeight = FontWeight.Medium,
             color = TypeTone.secondary,
+            lineHeight = TypeScale.label,
             modifier = Modifier.weight(1f),
             maxLines = 1
         )
@@ -704,6 +733,7 @@ private fun RowItem(label: String, value: String) {
             fontWeight = FontWeight.SemiBold,
             color = TypeTone.primary,
             textAlign = TextAlign.Right,
+            lineHeight = TypeScale.label,
             modifier = Modifier.wrapContentWidth(Alignment.End),
             maxLines = 1
         )
@@ -728,24 +758,24 @@ private fun AsrSub(
             fontSize = TypeScale.subLabel,
             fontWeight = FontWeight.Medium,
             color = TypeTone.dim,
+            lineHeight = TypeScale.subLabel,
             modifier = Modifier.weight(1f),
             maxLines = 1
         )
-        Box(
-            Modifier
-                .width(indicatorWidth)
-                .height(indicatorHeight)
-                .clip(RoundedCornerShape(indicatorRadius))
-                .background(Tokens.Colors.tickFull)
-        )
-        Spacer(Modifier.width(spacing))
-        Box(
-            Modifier
-                .width(indicatorWidth)
-                .height(indicatorHeight)
-                .clip(RoundedCornerShape(indicatorRadius))
-                .background(Tokens.Colors.tickFull)
-        )
+        Row(
+            modifier = Modifier.wrapContentWidth(Alignment.End),
+            horizontalArrangement = Arrangement.spacedBy(spacing)
+        ) {
+            repeat(2) {
+                Box(
+                    Modifier
+                        .width(indicatorWidth)
+                        .height(indicatorHeight)
+                        .clip(RoundedCornerShape(indicatorRadius))
+                        .background(Tokens.Colors.tickFull)
+                )
+            }
+        }
         Spacer(Modifier.width(spacing))
         Text(
             text = value,
@@ -753,10 +783,21 @@ private fun AsrSub(
             fontWeight = FontWeight.SemiBold,
             color = TypeTone.secondary,
             textAlign = TextAlign.Right,
+            lineHeight = TypeScale.subLabel,
             modifier = Modifier.wrapContentWidth(Alignment.End),
             maxLines = 1
         )
     }
+}
+
+@Composable
+private fun SectionHeading(text: String) {
+    Text(
+        text = text,
+        fontSize = TypeScale.label,
+        fontWeight = FontWeight.SemiBold,
+        color = TypeTone.primary
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- rebalance typography scale for the main dashboard card and city pill
- rebuild the prayer-time card layout to keep rows aligned and avoid clipping
- restyle the night-sections toggle to match the glass design accents

## Testing
- ./gradlew -Dorg.gradle.console=plain :app:compileDebugKotlin *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68f2494e1920832d93b44c16b6665e7b