### PR TITLE
Use BoxWithConstraints maxHeight in city picker

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -112,7 +112,7 @@ fun CityPickerWheel(
 
     BoxWithConstraints(modifier.clipToBounds()) {
         val itemHeight = with(density) { (92f * sy).dp.toPx() }
-        val viewportHeight = constraints.maxHeight.toFloat().coerceAtLeast(1f)
+        val viewportHeight = with(density) { maxHeight.toPx() }.coerceAtLeast(1f)
         val verticalPadding = ((viewportHeight - itemHeight) / 2f).coerceAtLeast(0f)
         val paddingDp = with(density) { verticalPadding.toDp() }
         val centerIndex by remember { derivedStateOf { listState.closestCenterItem() } }


### PR DESCRIPTION
## Summary
- derive the wheel viewport height from BoxWithConstraints.maxHeight so the scope is consumed
- keep padding calculations unchanged while avoiding the Compose scope warning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f288b993f8832dbb82feb285df4aa4