### PR TITLE
Refine prayer and city UI glass styling

### DIFF
--- a/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCarousel.kt
@@ -4,6 +4,8 @@ import android.os.SystemClock
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.ScrollScope
@@ -31,6 +33,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -38,12 +42,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.abys.R
 import com.example.abys.data.EffectId
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
+import com.example.abys.ui.util.backdropBlur
 import kotlin.math.abs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
@@ -68,7 +74,8 @@ fun EffectCarousel(
     val cardWidth: Dp = Dimens.scaledX(R.dimen.abys_thumb_w)
     val cardHeight: Dp = Dimens.scaledY(R.dimen.abys_thumb_h)
     val cardRadius = Tokens.Radii.chip()
-    val itemSpacing = 40.dp
+    val cardElevation = (18f * Dimens.s()).dp
+    val itemSpacing = (28f * Dimens.sx()).dp
 
     val repeatedItems = remember(items) {
         val source = items.ifEmpty { return@remember emptyList() }
@@ -189,9 +196,11 @@ fun EffectCarousel(
                 val distance = distanceToCenter(index, listState, viewportWidthPx)
                 val scale = scaleForDistance(distance)
                 val alpha = alphaForDistance(distance)
+                val shadowElevation = cardElevation * alpha
 
                 Card(
                     modifier = Modifier
+                        .shadow(shadowElevation, RoundedCornerShape(cardRadius), clip = false)
                         .size(cardWidth, cardHeight)
                         .graphicsLayer {
                             scaleX = scale
@@ -210,23 +219,54 @@ fun EffectCarousel(
                         }
                     }
                 ) {
-                    Image(
-                        painter = painterResource(item.resId),
-                        contentDescription = item.id.name,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize()
-                    )
-
-                    if (item.id == selected) {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(cardRadius))
+                    ) {
                         Box(
-                            modifier = Modifier
-                                .fillMaxSize()
+                            Modifier
+                                .matchParentSize()
+                                .backdropBlur((6f * Dimens.s()).dp)
                                 .border(
-                                    width = 2.dp,
-                                    color = Tokens.Colors.separator,
+                                    BorderStroke(
+                                        width = 1.dp,
+                                        brush = Brush.verticalGradient(
+                                            0f to Color.White.copy(alpha = 0.12f),
+                                            1f to Color.White.copy(alpha = 0.08f)
+                                        )
+                                    ),
                                     shape = RoundedCornerShape(cardRadius)
                                 )
                         )
+
+                        Image(
+                            painter = painterResource(item.resId),
+                            contentDescription = item.id.name,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+
+                        val selectionStroke = BorderStroke(
+                            width = 1.5.dp,
+                            brush = Brush.verticalGradient(
+                                0f to Tokens.Colors.separator,
+                                1f to Color.White.copy(alpha = 0.4f)
+                            )
+                        )
+                        if (item.id == selected) {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .border(selectionStroke, RoundedCornerShape(cardRadius))
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .background(Color.Black.copy(alpha = 0.08f))
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CityPickerWheel.kt
@@ -51,7 +51,10 @@ import com.example.abys.data.CityEntry
 import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
+import com.example.abys.ui.util.backdropBlur
 import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.pow
 import kotlinx.coroutines.flow.filter
 
 private const val VISIBLE_AROUND = 4
@@ -151,8 +154,9 @@ fun CityPickerWheel(
         ) {
             itemsIndexed(cities, key = { index, entry -> entry.id + index }) { index, city ->
                 val distance = abs(centerIndex - index)
-                val scale = 0.60f + 0.40f * (1f - (distance / (VISIBLE_AROUND + 1f))).coerceIn(0f, 1f)
-                val alpha = (1f - distance / (VISIBLE_AROUND + 1f)).coerceIn(0.35f, 1f)
+                val distanceF = distance.toFloat()
+                val scale = 0.60f + 0.40f * exp(-((distanceF / 1.2f).pow(2)))
+                val alpha = exp(-((distanceF / 1.1f).pow(2))).coerceIn(0.28f, 1f)
                 val textSize = (42f * scale).coerceIn(22f, 42f)
 
                 BasicText(
@@ -190,19 +194,22 @@ fun CityPickerWheel(
                 .height(slotHeightDp)
                 .clip(highlightShape)
                 .border(1.dp, Tokens.Colors.chipStroke, highlightShape)
+                .backdropBlur((8f * s).dp)
+                .background(Color.White.copy(alpha = 0.04f))
         ) {
             Row(
                 Modifier
                     .align(Alignment.Center)
-                    .fillMaxWidth(0.74f),
+                    .fillMaxWidth(0.76f),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 repeat(2) {
                     Box(
                         Modifier
-                            .height(1.dp)
-                            .width((48f * sx).dp)
+                            .height((6f * sy).dp)
+                            .width((110f * sx).dp)
+                            .clip(RoundedCornerShape((3f * sy).dp))
                             .background(Tokens.Colors.text.copy(alpha = 0.6f))
                     )
                 }

--- a/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
@@ -4,6 +4,7 @@ package com.example.abys.ui.screen
 
 import android.os.Build
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -65,6 +66,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -76,6 +78,17 @@ import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
 import com.example.abys.ui.util.backdropBlur
+
+private object SheetDefaults {
+    val blur: Dp
+        @Composable get() = (10f * Dimens.s()).dp
+    val stroke: Color
+        @Composable get() = Color.White.copy(alpha = 0.22f)
+    val glow: Color
+        @Composable get() = Color.White.copy(alpha = 0.16f)
+    val elevation: Dp
+        @Composable get() = (28f * Dimens.s()).dp
+}
 
 @Composable
 fun CitySheet(
@@ -104,59 +117,77 @@ fun CitySheet(
         label = "sheet-glass-color"
     )
 
-    val shape = RoundedCornerShape((32f * s).dp)
+    val shape = RoundedCornerShape(Tokens.Radii.glass())
+    val panelWidth = (504f * sx).dp
+    val panelHeight = (990f * sy).dp
+    val panelPadding = PaddingValues(
+        start = (69f * sx).dp,
+        end = (69f * sx).dp,
+        top = (54f * sy).dp,
+        bottom = (54f * sy).dp
+    )
 
     Box(
         modifier
             .fillMaxSize()
-            .padding(horizontal = (28f * sx).dp, vertical = (28f * sy).dp)
+            .padding(panelPadding)
     ) {
         Box(
             Modifier
-                .matchParentSize()
-                .shadow(elevation = (24f * sy).dp, shape = shape, clip = false)
+                .align(Alignment.TopCenter)
+                .widthIn(max = panelWidth)
+                .heightIn(max = panelHeight)
+                .shadow(elevation = SheetDefaults.elevation, shape = shape, clip = false)
                 .clip(shape)
         ) {
             Box(
                 Modifier
                     .matchParentSize()
                     .clip(shape)
-                    .backdropBlur(8.dp)
+                    .backdropBlur(SheetDefaults.blur)
                     .background(backgroundColor)
+                    .border(
+                        width = 1.dp,
+                        brush = Brush.verticalGradient(
+                            0f to SheetDefaults.stroke,
+                            1f to SheetDefaults.glow
+                        ),
+                        shape = shape
+                    )
             )
             Column(
                 Modifier
                     .matchParentSize()
                     .clip(shape)
-                    .padding(bottom = navPadding.calculateBottomPadding())
+                    .padding(
+                        start = (36f * sx).dp,
+                        end = (36f * sx).dp,
+                        top = (64f * sy).dp,
+                        bottom = navPadding.calculateBottomPadding() + (36f * sy).dp
+                    )
             ) {
                 CityNameChip(
                     city = city,
                     modifier = Modifier
-                        .padding(top = (60f * sy).dp, start = (64f * sx).dp, end = (64f * sx).dp)
+                        .fillMaxWidth()
                         .pointerInput(Unit) { detectTapGestures { onCityChipTap() } }
                 )
 
-                Spacer(Modifier.height((48f * sy).dp))
+                Spacer(Modifier.height((32f * sy).dp))
 
-                Box(
-                    Modifier
-                        .padding(horizontal = (72f * sx).dp)
+                HadithFrame(
+                    text = hadith,
+                    modifier = Modifier
                         .fillMaxWidth()
-                ) {
-                    HadithFrame(
-                        text = hadith,
-                        modifier = Modifier
-                            .fillMaxWidth(0.8f)
-                            .align(Alignment.Center)
-                    )
-                }
+                        .padding(horizontal = (12f * sx).dp)
+                        .animateContentSize(animationSpec = tween(durationMillis = 220))
+                )
 
-                Spacer(Modifier.height((36f * sy).dp))
+                Spacer(Modifier.height((28f * sy).dp))
 
                 CitySheetTabs(activeTab = activeTab, onTabSelected = onTabSelected)
 
-                Spacer(Modifier.height((24f * sy).dp))
+                Spacer(Modifier.height((20f * sy).dp))
 
                 Crossfade(
                     targetState = activeTab,
@@ -171,7 +202,7 @@ fun CitySheet(
                                 onChosen = onCityChosen,
                                 modifier = Modifier
                                     .weight(1f)
-                                    .padding(horizontal = (24f * sx).dp)
+                                    .padding(horizontal = (12f * sx).dp)
                             )
                         }
 
@@ -181,14 +212,14 @@ fun CitySheet(
                                 modifier = Modifier
                                     .weight(1f)
                                     .fillMaxWidth()
-                                    .padding(horizontal = (24f * sx).dp),
+                                    .padding(horizontal = (12f * sx).dp),
                                 onCityChosen = onCityChosen
                             )
                         }
                     }
                 }
 
-                Spacer(Modifier.height((32f * sy).dp))
+                Spacer(Modifier.height((12f * sy).dp))
             }
         }
     }
@@ -197,15 +228,24 @@ fun CitySheet(
 @Composable
 private fun CityNameChip(city: String, modifier: Modifier = Modifier) {
     val s = Dimens.s()
+    val sy = Dimens.sy()
     val shape = RoundedCornerShape((24f * s).dp)
-    val chipSize = ((36f * s).coerceIn(24f, 36f)).sp
+    val chipSize = ((36f * s).coerceIn(24f, 34f)).sp
+    val strokeWidth = (3f * Dimens.sx()).dp
 
     Box(
         modifier
             .fillMaxWidth()
-            .sizeIn(minHeight = (64f * s).dp)
-            .border(width = 1.dp, color = Color.White.copy(alpha = 0.12f), shape = shape)
-            .padding(horizontal = (18f * s).dp),
+            .sizeIn(minHeight = (64f * sy).dp)
+            .border(
+                width = strokeWidth,
+                brush = Brush.verticalGradient(
+                    0f to Color.White.copy(alpha = 0.24f),
+                    1f to Color.White.copy(alpha = 0.14f)
+                ),
+                shape = shape
+            )
+            .padding(horizontal = (16f * s).dp),
         contentAlignment = Alignment.Center
     ) {
         BasicText(
@@ -239,8 +279,8 @@ private fun CitySheetTabs(activeTab: CitySheetTab, onTabSelected: (CitySheetTab)
             TabRowDefaults.Indicator(
                 modifier = Modifier
                     .tabIndicatorOffset(tabPositions[tabs.indexOf(activeTab)])
-                    .height(2.dp),
-                color = Tokens.Colors.text
+                    .height(1.dp),
+                color = Tokens.Colors.text.copy(alpha = 0.74f)
             )
         }
     ) {

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -115,10 +115,18 @@ private enum class SurfaceStage { Dashboard, CitySheet, CityPicker }
 
 // Тоны серого стекла и параметры блюра — под эталонный макет
 private object GlassDefaults {
-    val top = Color.White.copy(alpha = 0.26f)
-    val bottom = Color.White.copy(alpha = 0.22f)
-    val stroke = Color.White.copy(alpha = 0.18f)
-    val blur = 8.dp
+    val top: Color
+        @Composable get() = Tokens.Colors.overlayTop.copy(alpha = 0.9f)
+    val bottom: Color
+        @Composable get() = Tokens.Colors.overlayCard.copy(alpha = 0.86f)
+    val stroke: Color
+        @Composable get() = Color.White.copy(alpha = 0.32f)
+    val glow: Color
+        @Composable get() = Color.White.copy(alpha = 0.18f)
+    val blur: Dp
+        @Composable get() = (10f * Dimens.s()).dp
+    val elevation: Dp
+        @Composable get() = (24f * Dimens.s()).dp
     val bgScrim = Color.Black.copy(alpha = 0.25f)
 }
 
@@ -134,13 +142,13 @@ private object Dur {
 // Палитра и типографика под «серый» макет
 private object TypeTone {
     val primary: Color
-        @Composable get() = Tokens.Colors.text.copy(alpha = 0.92f)
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.96f)
     val secondary: Color
-        @Composable get() = Tokens.Colors.text.copy(alpha = 0.78f)
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.88f)
     val dim: Color
-        @Composable get() = Tokens.Colors.text.copy(alpha = 0.62f)
+        @Composable get() = Tokens.Colors.text.copy(alpha = 0.7f)
     val divider: Color
-        @Composable get() = Color.White.copy(alpha = 0.06f)
+        @Composable get() = Color.White.copy(alpha = 0.16f)
 }
 
 private const val TABULAR_FEATURE = "'tnum'"
@@ -177,7 +185,7 @@ private fun TabularText(
 
 @Composable
 private fun ThinDivider(modifier: Modifier = Modifier) {
-    HorizontalDivider(modifier = modifier, color = TypeTone.divider, thickness = 0.75.dp)
+    HorizontalDivider(modifier = modifier, color = TypeTone.divider, thickness = 1.dp)
 }
 
 @Composable
@@ -219,12 +227,12 @@ private fun MutedBackgroundCrossfade(effect: EffectId) {
 private fun scaledSp(basePx: Int, scale: Float) = (basePx * scale).roundToInt().sp
 
 private object TypeScale {
-    val eyebrow = scaledSp(Tokens.TypographyPx.timeline, 0.6f)
-    val city = scaledSp(Tokens.TypographyPx.city, 0.76f)
-    val timeNow = scaledSp(Tokens.TypographyPx.timeNow, 0.76f)
-    val label = scaledSp(Tokens.TypographyPx.label, 0.7f)
-    val subLabel = scaledSp(Tokens.TypographyPx.subLabel, 0.68f)
-    val timeline = scaledSp(Tokens.TypographyPx.timeline, 0.66f)
+    val eyebrow = scaledSp(Tokens.TypographyPx.timeline, 0.52f)
+    val city = scaledSp(Tokens.TypographyPx.city, 0.68f)
+    val timeNow = scaledSp(Tokens.TypographyPx.timeNow, 0.68f)
+    val label = scaledSp(Tokens.TypographyPx.label, 0.62f)
+    val subLabel = scaledSp(Tokens.TypographyPx.subLabel, 0.6f)
+    val timeline = scaledSp(Tokens.TypographyPx.timeline, 0.6f)
 }
 
 @Composable
@@ -395,22 +403,22 @@ fun MainScreen(
     }
 
     BoxWithConstraints(Modifier.fillMaxSize()) {
-        val maxH = maxHeight
-        val bottomSafe = navPadding.calculateBottomPadding()
-        val topPad = maxOf(16.dp, maxH * 0.18f)
-        val availableCardHeight = (maxH - topPad - bottomSafe - 96.dp).coerceAtLeast(0.dp)
-        val minCardHeight = minOf(maxH * 0.62f, availableCardHeight)
+        val headerOffsetY = (79f * sy).dp
+        val headerHorizontal = (67f * sx).dp
+        val headerWidth = (533f * sx).dp
+        val cardOffsetY = (226f * sy).dp
+        val cardHorizontal = (64f * sx).dp
+        val cardMaxWidth = (508f * sx).dp
+        val cardMaxHeight = (611f * sy).dp
+        val carouselBottomOffset = navPadding.calculateBottomPadding() + (48f * sy).dp
 
         HeaderPill(
             city = city,
             now = now,
             modifier = Modifier
-                .padding(
-                    start = (51f * sx).dp,
-                    top = (79f * sy).dp,
-                    end = (51f * sx).dp
-                )
-                .height((102f * sy).dp)
+                .align(Alignment.TopCenter)
+                .padding(top = headerOffsetY, start = headerHorizontal, end = headerHorizontal)
+                .widthIn(max = headerWidth)
                 .graphicsLayer {
                     alpha = headerAlpha
                     translationY = headerTranslation
@@ -426,12 +434,10 @@ fun MainScreen(
         }
 
         val prayerModifier = Modifier
-            .padding(
-                start = (64f * sx).dp,
-                end = (64f * sx).dp,
-                top = topPad
-            )
-            .heightIn(min = minCardHeight)
+            .align(Alignment.TopCenter)
+            .padding(top = cardOffsetY, start = cardHorizontal, end = cardHorizontal)
+            .widthIn(max = cardMaxWidth)
+            .heightIn(max = cardMaxHeight)
             .graphicsLayer {
                 val explodedAlpha = if (exploded) 0f else 1f
                 val explodedScale = if (exploded) 1.08f else 1f
@@ -472,7 +478,7 @@ fun MainScreen(
             enabled = stage == SurfaceStage.Dashboard && !isTransitioning,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = navPadding.calculateBottomPadding() + (56f * sy).dp)
+                .padding(bottom = carouselBottomOffset)
                 .graphicsLayer {
                     alpha = carouselAlpha
                     if (stage == SurfaceStage.Dashboard) {
@@ -553,13 +559,13 @@ private fun HeaderPill(
     val sy = Dimens.sy()
     val horizontalPadding = Dimens.scaledX(R.dimen.abys_pill_pad_h)
     val verticalPadding = Dimens.scaledY(R.dimen.abys_pill_pad_v)
-    val eyebrowSpacing = (6f * sy).dp
+    val eyebrowSpacing = (4f * sy).dp
     val shape = RoundedCornerShape(Tokens.Radii.pill())
 
     Box(
         modifier
             .fillMaxWidth()
-            .shadow(elevation = (36f * sy).dp, shape = shape, clip = false)
+            .shadow(elevation = GlassDefaults.elevation, shape = shape, clip = false)
             .clip(shape)
             .graphicsLayer { compositingStrategy = CompositingStrategy.ModulateAlpha }
     ) {
@@ -571,7 +577,14 @@ private fun HeaderPill(
                 .background(
                     Brush.verticalGradient(listOf(GlassDefaults.top, GlassDefaults.bottom))
                 )
-                .border(width = 1.dp, color = GlassDefaults.stroke, shape = shape)
+                .border(
+                    width = 1.dp,
+                    brush = Brush.verticalGradient(
+                        0f to GlassDefaults.stroke,
+                        1f to GlassDefaults.glow
+                    ),
+                    shape = shape
+                )
         )
         Box(
             Modifier
@@ -635,14 +648,15 @@ private fun PrayerCard(
     val sx = Dimens.sx()
     val sy = Dimens.sy()
     val shape = RoundedCornerShape(Tokens.Radii.card())
-    val rowSpacing = (12f * sy).dp
-    val sectionSpacing = (22f * sy).dp
-    val asrSpacing = (8f * sy).dp
-    val asrLineHeight = (1.2f * sy).dp
-    val asrGap = (10f * sx).dp
+    val rowSpacing = (16f * sy).dp
+    val sectionSpacing = (28f * sy).dp
+    val asrSpacing = (12f * sy).dp
+    val asrLineHeight = (2f * sy).dp
+    val asrGap = (12f * sx).dp
     Box(
         modifier
             .fillMaxWidth()
+            .shadow(elevation = GlassDefaults.elevation, shape = shape, clip = false)
             .clip(shape)
             .graphicsLayer { compositingStrategy = CompositingStrategy.ModulateAlpha }
     ) {
@@ -654,7 +668,14 @@ private fun PrayerCard(
                 .background(
                     Brush.verticalGradient(listOf(GlassDefaults.top, GlassDefaults.bottom))
                 )
-                .border(width = 1.dp, color = GlassDefaults.stroke, shape = shape)
+                .border(
+                    width = 1.dp,
+                    brush = Brush.verticalGradient(
+                        0f to GlassDefaults.stroke,
+                        1f to GlassDefaults.glow
+                    ),
+                    shape = shape
+                )
         )
         Column(
             Modifier
@@ -725,7 +746,6 @@ private fun PrayerCard(
 private fun PrayerRow(label: String, value: String) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(

--- a/app/src/main/res/values/tokens_colors.xml
+++ b/app/src/main/res/values/tokens_colors.xml
@@ -1,11 +1,11 @@
 <resources>
     <!-- Альфы в ARGB (#AARRGGBB) -->
     <color name="abys_fg">#FFFFFFFF</color>
-    <color name="abys_overlayTop">#42000000</color>
-    <color name="abys_overlayCard">#42000000</color>
+    <color name="abys_overlayTop">#5C000000</color>
+    <color name="abys_overlayCard">#4F000000</color>
     <color name="abys_tickFull">#FFFFFFFF</color>
     <color name="abys_separator50">#80FFFFFF</color>
-    <color name="abys_chipStroke">#1FFFFFFF</color>
+    <color name="abys_chipStroke">#5CFFFFFF</color>
     <color name="abys_quoteStroke">#D9000000</color>
     <color name="abys_glassSheetBlur">#42FFFFFF</color>
     <color name="abys_glassPickerBlur">#33FFFFFF</color>

--- a/app/src/main/res/values/tokens_dimens.xml
+++ b/app/src/main/res/values/tokens_dimens.xml
@@ -1,13 +1,13 @@
 <resources>
     <!-- Радиусы -->
-    <dimen name="abys_radius_pill">22dp</dimen>
-    <dimen name="abys_radius_card">28dp</dimen>
+    <dimen name="abys_radius_pill">35dp</dimen>
+    <dimen name="abys_radius_card">30dp</dimen>
     <dimen name="abys_radius_chip">22dp</dimen>
     <dimen name="abys_radius_list">28dp</dimen>
 
     <!-- Паддинги/сетка из спека -->
     <dimen name="abys_pill_pad_h">24dp</dimen>
-    <dimen name="abys_pill_pad_v">18dp</dimen>
+    <dimen name="abys_pill_pad_v">14dp</dimen>
     <dimen name="abys_card_pad_h">44dp</dimen>
     <dimen name="abys_card_pad_top">45dp</dimen>
     <dimen name="abys_card_pad_bottom">40dp</dimen>


### PR DESCRIPTION
## Summary
- tune glass radii, typography scale, and layout offsets so the header pill and prayer card match the lighter spec spacing
- refresh the prayer card and effect carousel glass treatments with stronger blur, shadow, and selection feedback
- rebuild the city sheet and picker chrome with balanced padding, translucent backgrounds, and clearer selection emphasis

## Testing
- ./gradlew lint *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68f28db95d54832daafe02b454b3faaf