### PR TITLE
Fix missing Compose layout modifier imports

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/CitySheet.kt
@@ -25,10 +25,12 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState


### PR DESCRIPTION
## Summary
- add the missing widthIn and heightIn layout modifier imports to CitySheet
- ensure the sheet container can compile with the correct Compose extensions available

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2944b18bc832dbfba73a6bba06cb1