### PR TITLE
Guard dimension scaling against zero configuration

### DIFF
--- a/app/src/main/java/com/example/abys/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/example/abys/ui/theme/Dimens.kt
@@ -13,10 +13,18 @@ import androidx.compose.ui.unit.dp
  */
 object Dimens {
     @Composable
-    fun sx(): Float = LocalConfiguration.current.screenWidthDp / 636f
+    fun sx(): Float {
+        val width = LocalConfiguration.current.screenWidthDp
+        val safeWidth = if (width > 0) width else 636
+        return safeWidth / 636f
+    }
 
     @Composable
-    fun sy(): Float = LocalConfiguration.current.screenHeightDp / 1131f
+    fun sy(): Float {
+        val height = LocalConfiguration.current.screenHeightDp
+        val safeHeight = if (height > 0) height else 1131
+        return safeHeight / 1131f
+    }
 
     @Composable
     fun s(): Float = (sx() + sy()) * 0.5f


### PR DESCRIPTION
## Summary
- prevent the adaptive dimension helpers from returning zero when the configuration is not yet populated
- use design-time defaults for width and height to keep the prayer card and header visible during startup

## Testing
- `./gradlew -q :app:lintDebug` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f297a1c5f8832d9dc9c0d0a3303290