### PR TITLE
Improve splash playback layout and navigation

### DIFF
--- a/app/src/main/java/com/example/abys/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/SplashActivity.kt
@@ -10,7 +10,14 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.media3.common.PlaybackException
 import com.example.abys.R
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class SplashActivity : AppCompatActivity() {
@@ -18,12 +25,22 @@ class SplashActivity : AppCompatActivity() {
     private lateinit var player: ExoPlayer
     private lateinit var playerView: PlayerView
     private lateinit var placeholderView: ImageView
+    private var navigationJob: Job? = null
+    private var hasNavigated = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
         setContentView(R.layout.activity_splash)          // ← подключаем XML-layout
 
         playerView = findViewById(R.id.playerView)        // ← из разметки
+        playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
         placeholderView = findViewById<ImageView>(R.id.placeholderView)
 
         val mediaItem = MediaItem.Builder()
@@ -45,21 +62,19 @@ class SplashActivity : AppCompatActivity() {
                     override fun onPlaybackStateChanged(state: Int) {
                         when (state) {
                             Player.STATE_READY -> {
-                                if (placeholderView.isVisible) {
-                                    placeholderView.animate()
-                                        .alpha(0f)
-                                        .setDuration(220L)
-                                        .withEndAction { placeholderView.isVisible = false }
-                                        .start()
-                                }
+                                placeholderView.isVisible = false
                                 if (!isPlaying) play()
                             }
 
                             Player.STATE_ENDED -> {
-                                startActivity(Intent(this@SplashActivity, MainActivity::class.java))
-                                finish()
+                                navigateToMain()
                             }
                         }
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        placeholderView.isVisible = true
+                        navigateToMain()
                     }
                 })
             }
@@ -72,10 +87,29 @@ class SplashActivity : AppCompatActivity() {
         lifecycleScope.launch {
             player.prepare()
         }
+
+        navigationJob = lifecycleScope.launch {
+            delay(SPLASH_TIMEOUT_MS)
+            navigateToMain()
+        }
     }
 
     override fun onStop() {
         super.onStop()
         player.release()
+        navigationJob?.cancel()
+    }
+
+    private fun navigateToMain() {
+        if (hasNavigated) return
+        hasNavigated = true
+        navigationJob?.cancel()
+        startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+        finish()
+    }
+
+    companion object {
+        private const val SPLASH_TIMEOUT_MS = 2_500L
     }
 }

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -10,14 +10,17 @@
         android:id="@+id/playerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:use_controller="false"
-        app:resize_mode="zoom" />
+        android:background="@android:color/black"
+        app:resize_mode="fill"
+        app:surface_type="texture_view"
+        app:use_controller="false" />
 
     <ImageView
         android:id="@+id/placeholderView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:contentDescription="@null"
         android:scaleType="centerCrop"
         android:src="@drawable/thumb_sunset_snow"
-        android:contentDescription="@null" />
+        android:visibility="gone" />
 </FrameLayout>


### PR DESCRIPTION
## Summary
- stretch the splash video to fill the entire screen and keep the placeholder hidden unless needed
- hide system UI during the splash animation and add a timeout/error path that always opens the main screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2a34dde4c832daec57bc071384aa0