### PR TITLE
Fix prayer card visibility after double tap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,4 +88,3 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
-}

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -439,9 +439,8 @@ fun MainScreen(
             .widthIn(max = cardMaxWidth)
             .heightIn(max = cardMaxHeight)
             .graphicsLayer {
-                val explodedAlpha = if (exploded) 0f else 1f
                 val explodedScale = if (exploded) 1.08f else 1f
-                alpha = prayerAlpha * explodedAlpha
+                alpha = prayerAlpha
                 scaleX = prayerScale * explodedScale
                 scaleY = prayerScale * explodedScale
                 translationY = prayerTranslation

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,3 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
     id 'org.jetbrains.kotlin.plugin.compose' version '2.0.0' apply false
 }
-}


### PR DESCRIPTION
## Summary
- prevent the dashboard prayer card from becoming fully transparent when the double-tap "explode" gesture is triggered so it stays visible while still scaling up
- tidy the project Gradle scripts by removing stray closing braces to restore a valid configuration block

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a821622c832da7eb0bbad1df24d2