### PR TITLE
Keep prayer card mounted when sheet is open

### DIFF
--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -122,6 +122,11 @@ class MainViewModel : ViewModel() {
         }
     }
 
+    fun hideSheet() {
+        _sheetVisible.value = false
+        _sheetTab.value = CitySheetTab.Wheel
+    }
+
     fun setSheetTab(tab: CitySheetTab) {
         _sheetTab.value = tab
     }

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -256,6 +256,7 @@ fun MainApp(
 
     LaunchedEffect(Unit) {
         vm.restorePersisted(context.applicationContext)
+        vm.hideSheet()
     }
 
     CompositionLocalProvider(LocalTextStyle provides LocalTextStyle.current.copy(fontFamily = AbysFonts.inter)) {
@@ -446,29 +447,21 @@ fun MainScreen(
                 translationY = prayerTranslation
             }
 
-        if (prayerAlpha > 0.01f) {
-            AnimatedVisibility(
-                visible = !showSheet,
-                enter = fadeIn(tween(Dur.BASE)) + scaleIn(initialScale = 0.96f, animationSpec = tween(Dur.BASE)),
-                exit = fadeOut(tween(Dur.X_SHORT)) + scaleOut(targetScale = 0.96f, animationSpec = tween(Dur.X_SHORT))
-            ) {
-                PrayerCard(
-                    times = prayerTimes,
-                    thirds = thirds,
-                    modifier = if (stage == SurfaceStage.Dashboard) {
-                        prayerModifier.pointerInput(Unit) {
-                            detectTapGestures(
-                                onDoubleTap = {
-                                    if (!isTransitioning) exploded = !exploded
-                                }
-                            )
+        PrayerCard(
+            times = prayerTimes,
+            thirds = thirds,
+            modifier = if (stage == SurfaceStage.Dashboard) {
+                prayerModifier.pointerInput(Unit) {
+                    detectTapGestures(
+                        onDoubleTap = {
+                            if (!isTransitioning) exploded = !exploded
                         }
-                    } else {
-                        prayerModifier
-                    }
-                )
+                    )
+                }
+            } else {
+                prayerModifier
             }
-        }
+        )
 
         EffectCarousel(
             items = effectThumbs,


### PR DESCRIPTION
## Summary
- keep the PrayerCard in composition and control its visibility via alpha/scale instead of AnimatedVisibility
- ensure the city sheet is hidden immediately after restoring persisted UI state
- add a dedicated `hideSheet` helper on `MainViewModel` for reuse

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2b8aafc04832d9b1a9c115c873984