### PR TITLE
Reset city sheet visibility on restore

### DIFF
--- a/app/src/main/java/com/example/abys/logic/MainViewModel.kt
+++ b/app/src/main/java/com/example/abys/logic/MainViewModel.kt
@@ -151,6 +151,10 @@ class MainViewModel : ViewModel() {
     }
 
     fun restorePersisted(ctx: Context) {
+        // Гарантируем, что главный экран стартует в режиме Dashboard,
+        // даже если сохранённое состояние когда-то открыло city sheet.
+        _sheetVisible.value = false
+        _sheetTab.value = CitySheetTab.Wheel
         lastPersistContext = WeakReference(ctx.applicationContext)
         viewModelScope.launch(io) {
             val school = SettingsStore.getSchool(ctx)
@@ -186,6 +190,10 @@ class MainViewModel : ViewModel() {
                 !savedCity.isNullOrBlank() -> loadByCity(savedCity!!, ctx = ctx)
                 else -> loadByLocation(ctx)
             }
+
+            // Перестраховываемся на случай фоновых обновлений.
+            _sheetVisible.postValue(false)
+            _sheetTab.postValue(CitySheetTab.Wheel)
         }
     }
 


### PR DESCRIPTION
## Summary
- reset the city sheet visibility before restoring persisted state so the dashboard is visible after app restarts
- enforce the default sheet tab during and after restore to avoid stale UI state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2c2270010832db11ae54b40fdb548