### PR TITLE
Reset sheet visibility bootstrap in MainScreen

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -256,7 +256,16 @@ fun MainApp(
 
     LaunchedEffect(Unit) {
         vm.restorePersisted(context.applicationContext)
-        vm.hideSheet()
+    }
+
+    var hasBootstrappedSheet by remember { mutableStateOf(false) }
+    LaunchedEffect(showSheet) {
+        if (!hasBootstrappedSheet) {
+            if (showSheet) {
+                vm.hideSheet()
+            }
+            hasBootstrappedSheet = true
+        }
     }
 
     CompositionLocalProvider(LocalTextStyle provides LocalTextStyle.current.copy(fontFamily = AbysFonts.inter)) {


### PR DESCRIPTION
## Summary
- revert MainViewModel to its original sheet visibility logic instead of keeping the forced-hide guard
- hide a restored sheet once from MainApp when the first sheetVisible emission is true so the dashboard card stays visible after cold start

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2c2270010832db11ae54b40fdb548