### PR TITLE
Fix prayer card layout height

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -680,7 +680,7 @@ private fun PrayerCard(
         )
         Column(
             Modifier
-                .matchParentSize()
+                .fillMaxWidth()
                 .padding(
                     start = Dimens.scaledX(R.dimen.abys_card_pad_h),
                     end = Dimens.scaledX(R.dimen.abys_card_pad_h),


### PR DESCRIPTION
## Summary
- ensure the prayer card column sizes itself from its content so the dashboard tile renders

## Testing
- ./gradlew :app:test *(fails: Android SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a1b4da4c832d958ce3ee1bbaefa3