### PR TITLE
Fix density conversions for prayer dashboard transitions

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -82,11 +82,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.unit.toPx
 import com.example.abys.R
 import com.example.abys.data.FallbackContent
 import com.example.abys.data.CityEntry
@@ -151,6 +151,8 @@ private object TypeTone {
 private const val TABULAR_FEATURE = "'tnum'"
 
 private val TabularFeatureStyle = TextStyle(fontFeatureSettings = TABULAR_FEATURE)
+
+private fun Density.dpToPx(value: Float): Float = value * density
 
 @Composable
 private fun TabularText(
@@ -321,66 +323,66 @@ fun MainScreen(
         else -> SurfaceStage.CitySheet
     }
 
-    val transition = updateTransition(stage, label = "surface")
+    val transition = updateTransition(targetState = stage, label = "surface")
     // Предвычисляем px-значения, чтобы не трогать layout на каждую рекомпозицию
-    val sheetHiddenOffset = remember(density, sx) { with(density) { (236f * sx).dp.toPx() } }
-    val sheetLift = remember(density, sy) { with(density) { (18f * sy).dp.toPx() } }
-    val cardLift = remember(density, sy) { with(density) { (42f * sy).dp.toPx() } }
-    val carouselDrop = remember(density, sy) { with(density) { (36f * sy).dp.toPx() } }
-    val headerLift = remember(density, sy) { with(density) { (14f * sy).dp.toPx() } }
+    val sheetHiddenOffset: Float = remember(density, sx) { density.dpToPx(236f * sx) }
+    val sheetLift: Float = remember(density, sy) { density.dpToPx(18f * sy) }
+    val cardLift: Float = remember(density, sy) { density.dpToPx(42f * sy) }
+    val carouselDrop: Float = remember(density, sy) { density.dpToPx(36f * sy) }
+    val headerLift: Float = remember(density, sy) { density.dpToPx(14f * sy) }
 
     val prayerAlpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = if (targetState == SurfaceStage.Dashboard) Dur.SHORT else Dur.MED) },
         label = "prayerAlpha"
-    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 1f else 0f }
     val prayerScale by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "prayerScale"
-    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.94f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 1f else 0.94f }
     val prayerTranslation by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "prayerTranslation"
-    ) { st -> if (st == SurfaceStage.Dashboard) 0f else -cardLift }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 0f else -cardLift }
 
     val headerAlpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "headerAlpha"
-    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.82f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 1f else 0.82f }
     val headerTranslation by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "headerTranslation"
-    ) { st -> if (st == SurfaceStage.Dashboard) 0f else -headerLift }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 0f else -headerLift }
 
     val carouselAlpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "carouselAlpha"
-    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.45f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 1f else 0.45f }
     val carouselScale by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "carouselScale"
-    ) { st -> if (st == SurfaceStage.Dashboard) 1f else 0.92f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 1f else 0.92f }
     val carouselTranslation by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "carouselTranslation"
-    ) { st -> if (st == SurfaceStage.Dashboard) 0f else carouselDrop }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 0f else carouselDrop }
 
     val scrimAlpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.BASE) },
         label = "scrimAlpha"
-    ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 0f else 1f }
 
     val sheetAlpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.MED) },
         label = "sheetAlpha"
-    ) { st -> if (st == SurfaceStage.Dashboard) 0f else 1f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) 0f else 1f }
     val sheetTranslationX by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetTranslationX"
-    ) { st -> if (st == SurfaceStage.Dashboard) sheetHiddenOffset else 0f }
+    ) { st: SurfaceStage -> if (st == SurfaceStage.Dashboard) sheetHiddenOffset else 0f }
     val sheetTranslationY by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetTranslationY"
-    ) { st ->
+    ) { st: SurfaceStage ->
         when (st) {
             SurfaceStage.Dashboard -> sheetLift
             SurfaceStage.CitySheet -> 0f
@@ -390,7 +392,7 @@ fun MainScreen(
     val sheetScale by transition.animateFloat(
         transitionSpec = { tween(durationMillis = Dur.LONG) },
         label = "sheetScale"
-    ) { st ->
+    ) { st: SurfaceStage ->
         when (st) {
             SurfaceStage.Dashboard -> 0.9f
             SurfaceStage.CitySheet -> 1f


### PR DESCRIPTION
## Summary
- replace Dp.toPx() calls with density-based helpers compatible with Kotlin 2
- ensure cached transition offsets have explicit Float types for reliable inference

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3adc9669c832d8a6c719c9dec3ab6