### PR TITLE
Normalize city header pill title

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -421,8 +422,10 @@ fun MainScreen(
         val cardMaxWidth = (540f * sx).dp
         val carouselBottomOffset = navPadding.calculateBottomPadding() + (48f * sy).dp
 
+        val normalizedCity = remember(city) { city.substringBefore(',').ifBlank { city }.trim() }
+
         HeaderPill(
-            city = city,
+            city = normalizedCity,
             now = now,
             modifier = Modifier
                 .align(Alignment.TopCenter)
@@ -600,7 +603,9 @@ private fun HeaderPill(
             contentAlignment = Alignment.CenterStart
         ) {
             Column(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = (4f * sy).dp),
                 verticalArrangement = Arrangement.spacedBy(headlineSpacing)
             ) {
                 Row(
@@ -609,17 +614,18 @@ private fun HeaderPill(
                     horizontalArrangement = Arrangement.spacedBy((12f * sx).dp)
                 ) {
                     Text(
-                        text = city,
+                        text = city.ifBlank { "—" },
                         fontSize = TypeScale.city,
                         fontWeight = FontWeight.Bold,
                         fontStyle = FontStyle.Italic,
                         color = TypeTone.primary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        textDecoration = TextDecoration.Underline
                     )
                     TabularText(
-                        text = now,
+                        text = now.ifBlank { "--:--" },
                         fontSize = TypeScale.timeNow,
                         fontWeight = FontWeight.SemiBold,
                         color = TypeTone.secondary,


### PR DESCRIPTION
## Summary
- trim the displayed city name on the dashboard header pill so it matches the mockup styling
- add underline styling and fallback values so the city selector tile remains visible even when data is missing

## Testing
- `./gradlew :app:lintDebug` *(fails: missing Android SDK in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d6fb22c8832db59c1b90419db1b0