### PR TITLE
Remove duplicate header composition

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -474,25 +474,6 @@ fun MainScreen(
             }
         )
 
-        val normalizedCity = remember(city) { city.substringBefore(',').ifBlank { city }.trim() }
-
-        HeaderPill(
-            city = normalizedCity,
-            now = now,
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(top = headerOffsetY, start = headerHorizontal, end = headerHorizontal)
-                .widthIn(max = headerWidth)
-                .zIndex(1f)
-                .graphicsLayer {
-                    alpha = headerAlpha
-                    translationY = headerTranslation
-                },
-            onTap = {
-                if (!isTransitioning) onCityPillClick()
-            }
-        )
-
         EffectCarousel(
             items = effectThumbs,
             selected = selectedEffect,


### PR DESCRIPTION
## Summary
- remove the duplicate normalized city computation and HeaderPill composition in MainScreen to resolve conflicting declarations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3df37104c832d99c3d0ffb5388d94