### PR TITLE
Improve splash greeting video playback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,7 @@ android {
 
     buildFeatures {
         compose true
+        viewBinding true
     }
 
     compileOptions {

--- a/app/src/main/java/com/example/abys/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/abys/ui/SplashActivity.kt
@@ -1,29 +1,65 @@
 package com.example.abys.ui
 
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
-import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
-import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.PlayerView
-import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
-import com.example.abys.R
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
+import com.example.abys.databinding.ActivitySplashBinding
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class SplashActivity : AppCompatActivity() {
 
-    private lateinit var player: ExoPlayer
-    private lateinit var playerView: PlayerView
-    private lateinit var placeholderView: ImageView
+    private lateinit var binding: ActivitySplashBinding
+    private var player: ExoPlayer? = null
     private var hasNavigated = false
+    private var hasFadedInVideo = false
+    private var fallbackJob: Job? = null
+    private var windowInsetsController: WindowInsetsControllerCompat? = null
+
+    private val playerListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    cancelFallback()
+                    fadeInVideo()
+                    ensureSystemBarsHidden()
+                    player?.takeIf { !it.isPlaying }?.play()
+                }
+
+                Player.STATE_ENDED -> navigateToMain()
+            }
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            @Player.DiscontinuityReason reason: Int
+        ) {
+            if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION ||
+                reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION
+            ) {
+                navigateToMain()
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            binding.placeholderView.isVisible = true
+            cancelFallback()
+            navigateToMain()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,63 +70,136 @@ class SplashActivity : AppCompatActivity() {
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
 
-        setContentView(R.layout.activity_splash)          // ← подключаем XML-layout
+        binding = ActivitySplashBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        windowInsetsController = WindowInsetsControllerCompat(window, binding.root)
 
-        playerView = findViewById(R.id.playerView)        // ← из разметки
-        playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
-        placeholderView = findViewById<ImageView>(R.id.placeholderView)
+        setupViews()
 
-        val mediaItem = MediaItem.Builder()
-            .setUri("asset:///greeting.mp4")
-            .build()
-
-        player = ExoPlayer.Builder(this)
-            .setUseLazyPreparation(true)
-            .build().apply {
-                setMediaItem(mediaItem)
-                playWhenReady = false
-                repeatMode = Player.REPEAT_MODE_OFF
-                addListener(object : Player.Listener {
-                    override fun onPlaybackStateChanged(state: Int) {
-                        when (state) {
-                            Player.STATE_READY -> {
-                                placeholderView.isVisible = false
-                                if (!isPlaying) play()
-                            }
-
-                            Player.STATE_ENDED -> {
-                                navigateToMain()
-                            }
-                        }
-                    }
-
-                    override fun onPlayerError(error: PlaybackException) {
-                        placeholderView.isVisible = true
-                        navigateToMain()
-                    }
-                })
-            }
-
-        playerView.apply {
-            player = this@SplashActivity.player
-            setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
+        if (!assetExists(ASSET_GREETING_VIDEO)) {
+            scheduleFallback()
+            return
         }
 
-        lifecycleScope.launch {
-            player.prepare()
-        }
+        initializePlayer()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        ensureSystemBarsHidden()
     }
 
     override fun onStop() {
         super.onStop()
-        player.release()
+        releasePlayer()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        releasePlayer()
+        cancelFallback()
+    }
+
+    private fun setupViews() = with(binding) {
+        playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+        playerView.alpha = 0f
+        placeholderView.isVisible = true
+        placeholderView.alpha = 1f
+    }
+
+    private fun initializePlayer() {
+        val mediaItem = MediaItem.Builder()
+            .setUri("asset:///$ASSET_GREETING_VIDEO")
+            .build()
+
+        player = ExoPlayer.Builder(this)
+            .setUseLazyPreparation(true)
+            .build()
+            .also { exoPlayer ->
+                exoPlayer.repeatMode = Player.REPEAT_MODE_OFF
+                exoPlayer.playWhenReady = false
+                exoPlayer.setMediaItem(mediaItem)
+                exoPlayer.addListener(playerListener)
+            }
+
+        binding.playerView.apply {
+            player = this@SplashActivity.player
+            setShutterBackgroundColor(Color.TRANSPARENT)
+            keepScreenOn = true
+        }
+
+        scheduleFallback()
+
+        lifecycleScope.launch {
+            runCatching { player?.prepare() }
+                .onFailure { navigateToMain() }
+        }
+    }
+
+    private fun fadeInVideo() {
+        if (hasFadedInVideo) return
+        hasFadedInVideo = true
+
+        binding.playerView.animate()
+            .alpha(1f)
+            .setDuration(FADE_DURATION_MS)
+            .start()
+
+        binding.placeholderView.animate()
+            .alpha(0f)
+            .setDuration(FADE_DURATION_MS)
+            .withEndAction {
+                binding.placeholderView.isVisible = false
+            }
+            .start()
+
+        ensureSystemBarsHidden()
+    }
+
+    private fun scheduleFallback() {
+        cancelFallback()
+        fallbackJob = lifecycleScope.launch {
+            delay(FALLBACK_DELAY_MS)
+            navigateToMain()
+        }
+    }
+
+    private fun cancelFallback() {
+        fallbackJob?.cancel()
+        fallbackJob = null
+    }
+
+    private fun ensureSystemBarsHidden() {
+        windowInsetsController?.hide(WindowInsetsCompat.Type.systemBars())
+    }
+
+    private fun assetExists(assetName: String): Boolean = runCatching {
+        assets.open(assetName).close()
+    }.isSuccess
+
+    private fun releasePlayer() {
+        player?.let { exoPlayer ->
+            exoPlayer.removeListener(playerListener)
+            exoPlayer.stop()
+            exoPlayer.clearMediaItems()
+            exoPlayer.release()
+        }
+        binding.playerView.player = null
+        player = null
     }
 
     private fun navigateToMain() {
         if (hasNavigated) return
         hasNavigated = true
+        cancelFallback()
         startActivity(Intent(this@SplashActivity, MainActivity::class.java))
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         finish()
+    }
+
+    companion object {
+        private const val FADE_DURATION_MS = 300L
+        private const val FALLBACK_DELAY_MS = 2_000L
+        private const val ASSET_GREETING_VIDEO = "greeting.mp4"
     }
 }

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/black"
-        app:resize_mode="fill"
+        android:alpha="0"
+        app:resize_mode="zoom"
         app:surface_type="texture_view"
         app:use_controller="false" />
 
@@ -22,6 +23,6 @@
         android:contentDescription="@null"
         android:scaleType="centerCrop"
         android:src="@drawable/thumb_sunset_snow"
-        android:visibility="gone" />
+        android:visibility="visible" />
 </FrameLayout>
 


### PR DESCRIPTION
## Summary
- enable view binding support in the app module to simplify splash UI access
- rework `SplashActivity` to crossfade from the placeholder, hide system bars reliably, add a timed fallback, and release player resources safely
- adjust the splash layout for an initial fade-in and zoomed video presentation

## Testing
- ./gradlew lint *(fails: Android SDK not available in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ec1c435c832db3560deac0636e56