### PR TITLE
Decouple effect carousel from slideshow backgrounds

### DIFF
--- a/app/src/main/java/com/example/abys/ui/EffectCatalog.kt
+++ b/app/src/main/java/com/example/abys/ui/EffectCatalog.kt
@@ -7,76 +7,55 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import com.example.abys.R
 import com.example.abys.data.EffectId
-import com.example.abys.ui.background.Slides
 
 private data class EffectAssets(
     val id: EffectId,
     val thumbnailName: String,
-    val backgroundNames: List<String>,
     val fallbackThumbnail: Int,
-    val fallbackBackgrounds: List<Int>,
 )
 
 private val effectAssets = listOf(
     EffectAssets(
         id = EffectId.leaves,
         thumbnailName = "thumb_leaves",
-        backgroundNames = themeBackgrounds("theme_leaves"),
         fallbackThumbnail = R.drawable.slide_01,
-        fallbackBackgrounds = listOf(R.drawable.slide_01),
     ),
     EffectAssets(
         id = EffectId.lightning,
         thumbnailName = "thumb_lightning",
-        backgroundNames = themeBackgrounds("theme_lightning"),
         fallbackThumbnail = R.drawable.slide_02,
-        fallbackBackgrounds = listOf(R.drawable.slide_02),
     ),
     EffectAssets(
         id = EffectId.night,
         thumbnailName = "thumb_night",
-        backgroundNames = themeBackgrounds("theme_night"),
         fallbackThumbnail = R.drawable.slide_03,
-        fallbackBackgrounds = listOf(R.drawable.slide_03),
     ),
     EffectAssets(
         id = EffectId.rain,
         thumbnailName = "thumb_rain",
-        backgroundNames = themeBackgrounds("theme_rain"),
         fallbackThumbnail = R.drawable.slide_04,
-        fallbackBackgrounds = listOf(R.drawable.slide_04),
     ),
     EffectAssets(
         id = EffectId.snow,
         thumbnailName = "thumb_snow",
-        backgroundNames = themeBackgrounds("theme_snow"),
         fallbackThumbnail = R.drawable.slide_05,
-        fallbackBackgrounds = listOf(R.drawable.slide_05),
     ),
     EffectAssets(
         id = EffectId.storm,
         thumbnailName = "thumb_storm",
-        backgroundNames = themeBackgrounds("theme_storm"),
         fallbackThumbnail = R.drawable.slide_06,
-        fallbackBackgrounds = listOf(R.drawable.slide_06),
     ),
     EffectAssets(
         id = EffectId.sunset_snow,
         thumbnailName = "thumb_sunset_snow",
-        backgroundNames = themeBackgrounds("theme_sunset_snow"),
         fallbackThumbnail = R.drawable.slide_07,
-        fallbackBackgrounds = listOf(R.drawable.slide_07),
     ),
     EffectAssets(
         id = EffectId.wind,
         thumbnailName = "thumb_wind",
-        backgroundNames = themeBackgrounds("theme_wind"),
         fallbackThumbnail = R.drawable.slide_08,
-        fallbackBackgrounds = listOf(R.drawable.slide_08),
     ),
 )
-
-private val effectAssetsById = effectAssets.associateBy { it.id }
 
 @Composable
 fun rememberEffectCatalogFromRes(): List<EffectThumb> {
@@ -89,26 +68,9 @@ fun rememberEffectCatalogFromRes(): List<EffectThumb> {
     }
 }
 
-@Composable
-fun rememberEffectBackgrounds(effect: EffectId): List<Int> {
-    val context = LocalContext.current
-    val configuration = LocalConfiguration.current
-    return remember(effect, context, configuration) {
-        effectAssetsById[effect]?.resolveBackgrounds(context) ?: Slides.all
-    }
-}
-
 private fun EffectAssets.resolveThumbnail(context: Context): Int {
     return resolveDrawableId(context, thumbnailName) ?: fallbackThumbnail
 }
-
-private fun EffectAssets.resolveBackgrounds(context: Context): List<Int> {
-    val resolved = backgroundNames.mapNotNull { name -> resolveDrawableId(context, name) }
-    return if (resolved.isNotEmpty()) resolved else fallbackBackgrounds
-}
-
-private fun themeBackgrounds(prefix: String): List<String> =
-    (1..4).map { index -> "${prefix}_bg${index.toString().padStart(2, '0')}" }
 
 private fun resolveDrawableId(context: Context, name: String): Int? {
     if (name.isBlank()) return null

--- a/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
+++ b/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
@@ -1,11 +1,7 @@
 package com.example.abys.ui.background
 
 import androidx.compose.runtime.Composable
-import com.example.abys.data.EffectId
-import com.example.abys.ui.rememberEffectBackgrounds
-
 @Composable
-fun BackgroundHost(effect: EffectId) {
-    val backgrounds = rememberEffectBackgrounds(effect)
-    SlideshowBackground(images = backgrounds)
+fun BackgroundHost() {
+    SlideshowBackground()
 }

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -220,10 +220,10 @@ private fun MutedBackgroundCrossfade(effect: EffectId) {
                             ).asComposeRenderEffect()
                         }
                 ) {
-                    BackgroundHost(effect = target)
+                    BackgroundHost()
                 }
             } else {
-                BackgroundHost(effect = target)
+                BackgroundHost()
                 Box(
                     Modifier
                         .matchParentSize()


### PR DESCRIPTION
## Summary
- remove background resource lookups from the effect catalog so the carousel only exposes thumbnails
- render the slideshow background independently of the currently selected effect

## Testing
- Not run (Android SDK unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f428ff7640832db2823553e15476a9