### PR TITLE
Hook background slideshow to selected effect

### DIFF
--- a/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
+++ b/app/src/main/java/com/example/abys/ui/background/EffectBackgroundHost.kt
@@ -1,7 +1,32 @@
 package com.example.abys.ui.background
 
+import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import com.example.abys.data.EffectId
+
 @Composable
-fun BackgroundHost() {
-    SlideshowBackground()
+fun BackgroundHost(effect: EffectId) {
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    val images = remember(effect, configuration) {
+        resolveEffectSlides(context, effect)
+    }
+    SlideshowBackground(images = images)
+}
+
+private fun resolveEffectSlides(context: Context, effect: EffectId): List<Int> {
+    val prefix = "theme_${effect.name}_bg"
+    val packageName = context.packageName
+    val resources = context.resources
+    val ids = buildList {
+        for (index in 1..4) {
+            val name = "%s%02d".format(prefix, index)
+            val id = resources.getIdentifier(name, "drawable", packageName)
+            if (id != 0) add(id)
+        }
+    }
+    return ids.ifEmpty { Slides.all }
 }

--- a/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/MainScreen.kt
@@ -9,30 +9,28 @@ import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -40,19 +38,15 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -92,9 +86,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import com.example.abys.R
-import com.example.abys.data.FallbackContent
 import com.example.abys.data.CityEntry
 import com.example.abys.data.EffectId
+import com.example.abys.data.FallbackContent
 import com.example.abys.logic.CitySheetTab
 import com.example.abys.logic.MainViewModel
 import com.example.abys.logic.NightIntervals
@@ -108,16 +102,15 @@ import com.example.abys.ui.theme.AbysFonts
 import com.example.abys.ui.theme.Dimens
 import com.example.abys.ui.theme.Tokens
 import com.example.abys.ui.util.backdropBlur
+import kotlinx.coroutines.delay
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
-import kotlinx.coroutines.delay
 
 private enum class SurfaceStage { Dashboard, CitySheet, CityPicker }
 
 private const val MAIN_OVERLAY_DELAY_MS = 180L
 private const val MAIN_OVERLAY_FADE_DURATION_MS = 520
-private const val MAIN_OVERLAY_FADE_DURATION_MS = 520L
 
 // Тоны серого стекла и параметры блюра — под эталонный макет
 private object GlassDefaults {
@@ -220,10 +213,10 @@ private fun MutedBackgroundCrossfade(effect: EffectId) {
                             ).asComposeRenderEffect()
                         }
                 ) {
-                    BackgroundHost()
+                    BackgroundHost(effect = target)
                 }
             } else {
-                BackgroundHost()
+                BackgroundHost(effect = target)
                 Box(
                     Modifier
                         .matchParentSize()
@@ -1046,5 +1039,3 @@ private fun GlassSheetContainer(
         Box(Modifier.matchParentSize(), content = content)
     }
 }
-
-


### PR DESCRIPTION
## Summary
- replace the MainScreen implementation with the provided version that adjusts animations, hints, and layout behavior
- feed the selected effect into the background host so themed slides are resolved per effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f42e87363c832d9db143aa0297cdda