### PR TITLE
Fix duplicated CityHeaderPill content

### DIFF
--- a/app/src/main/java/com/example/abys/ui/screen/PrayerDashboard.kt
+++ b/app/src/main/java/com/example/abys/ui/screen/PrayerDashboard.kt
@@ -268,43 +268,11 @@ private fun CityHeaderPill(city: String, now: String, onTap: () -> Unit, modifie
 
             Spacer(Modifier.width((20f * sx).dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            val cityText = city.ifBlank { "—" }
-            Text(
-                text = cityText,
-                fontSize = TypeScale.city,
-                fontWeight = FontWeight.SemiBold,
-                fontStyle = FontStyle.Italic,
-                color = TypeTone.primary,
-                fontFamily = AbysFonts.inter,
-                modifier = Modifier
-                    .weight(1f)
-                    .drawBehind {
-                        if (cityText.isNotBlank()) {
-                            val thickness = underlineThickness.toPx()
-                            val offset = underlineOffset.toPx()
-                            drawRect(
-                                color = TypeTone.primary,
-                                topLeft = Offset(0f, size.height + offset - thickness),
-                                size = Size(size.width, thickness)
-                            )
-                        }
-                    },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-
-            Spacer(Modifier.width((20f * sx).dp))
-
             TabularText(
                 text = now.ifBlank { "--:--" },
                 fontSize = TypeScale.timeNow,
                 fontWeight = FontWeight.Bold,
-                color = TypeTone.primary,
+                color = primaryColor,
                 textAlign = TextAlign.Right,
                 fontFamily = AbysFonts.inter,
                 modifier = Modifier.widthIn(min = 0.dp)


### PR DESCRIPTION
## Summary
- remove the duplicated CityHeaderPill row that left the composable unterminated
- reuse the shared primary color when rendering the header time text

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f43ed79f40832da119eb0e97f77337